### PR TITLE
Fix server verbose_logging=false overriding local force debug output

### DIFF
--- a/src/main/java/io/teak/sdk/configuration/DebugConfiguration.java
+++ b/src/main/java/io/teak/sdk/configuration/DebugConfiguration.java
@@ -18,6 +18,7 @@ public class DebugConfiguration {
 
     private boolean logLocal;
     private boolean logRemote;
+    private final boolean forceLocalLogging;
     private final boolean isDevelopmentBuild;
 
     public DebugConfiguration(@NonNull Context context, @NonNull IAndroidResources androidResources) {
@@ -40,7 +41,8 @@ public class DebugConfiguration {
         // Force debug output via Android resource
         {
             final Boolean forceDebugOutput = androidResources.getBooleanResource(TEAK_FORCE_DEBUG_OUTPUT);
-            if (forceDebugOutput != null && forceDebugOutput) {
+            this.forceLocalLogging = forceDebugOutput != null && forceDebugOutput;
+            if (this.forceLocalLogging) {
                 this.logLocal = true;
             }
         }
@@ -61,7 +63,10 @@ public class DebugConfiguration {
     }
 
     public void setLogPreferences(boolean logLocal, boolean logRemote) {
-        if (logLocal != this.logLocal) {
+        // Preserve local logging if forced by the io_teak_force_debug_output resource.
+        logLocal = this.forceLocalLogging || logLocal;
+
+        if (logLocal != this.logLocal || logRemote != this.logRemote) {
             try {
                 synchronized (Teak.PREFERENCES_FILE) {
                     SharedPreferences.Editor editor = this.preferences.edit();

--- a/test_app/app/src/test/java/io/teak/app/test/DebugConfigurationTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/DebugConfigurationTest.java
@@ -1,5 +1,6 @@
 package io.teak.app.test;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -24,11 +25,22 @@ public class DebugConfigurationTest extends TeakUnitTest {
         return (boolean) f.get(Teak.log);
     }
 
+    private boolean getLogRemotely() throws NoSuchFieldException, IllegalAccessException {
+        Field f = Log.class.getDeclaredField("logRemotely");
+        f.setAccessible(true);
+        return (boolean) f.get(Teak.log);
+    }
+
     private void reinitializeWithCurrentMocks() throws NoSuchFieldException, IllegalAccessException {
         TestHelpers.resetTeakConfiguration();
         if (!TeakConfiguration.initialize(context, objectFactory)) {
             throw new IllegalArgumentException("TeakConfiguration re-initialization failed.");
         }
+    }
+
+    @After
+    public void resetForceDebug() {
+        Teak.forceDebug = false;
     }
 
     @Test
@@ -53,5 +65,51 @@ public class DebugConfigurationTest extends TeakUnitTest {
         // This simulates the resource not being present in the app
 
         assertFalse("logLocally should be false when io_teak_force_debug_output resource is absent", getLogLocally());
+    }
+
+    // --- Server vs local logging interaction ---
+
+    @Test
+    public void serverFalse_doesNotOverrideForceDebugOutputResource() throws Exception {
+        when(androidResources.getBooleanResource(DebugConfiguration.TEAK_FORCE_DEBUG_OUTPUT)).thenReturn(true);
+        reinitializeWithCurrentMocks();
+
+        assertTrue("logLocally should be true before server response", getLogLocally());
+
+        TeakConfiguration.get().debugConfiguration.setLogPreferences(false, false);
+
+        assertTrue("logLocally should remain true after server sends verbose_logging=false", getLogLocally());
+    }
+
+    @Test
+    public void serverTrue_enablesLogging() throws Exception {
+        assertFalse("logLocally should be false before server response", getLogLocally());
+
+        TeakConfiguration.get().debugConfiguration.setLogPreferences(true, false);
+
+        assertTrue("logLocally should be true after server sends verbose_logging=true", getLogLocally());
+    }
+
+    @Test
+    public void serverFalse_disablesRemoteLogging() throws Exception {
+        TeakConfiguration.get().debugConfiguration.setLogPreferences(false, true);
+
+        assertTrue("logRemotely should be true after server enables it", getLogRemotely());
+
+        TeakConfiguration.get().debugConfiguration.setLogPreferences(false, false);
+
+        assertFalse("logRemotely should be false after server disables it", getLogRemotely());
+    }
+
+    @Test
+    public void serverFalse_disablesPreviouslyEnabledLocalLogging() throws Exception {
+        // Without the force resource, server-enabled local logging can be turned off
+        TeakConfiguration.get().debugConfiguration.setLogPreferences(true, false);
+
+        assertTrue("logLocally should be true after server enables it", getLogLocally());
+
+        TeakConfiguration.get().debugConfiguration.setLogPreferences(false, false);
+
+        assertFalse("logLocally should be false after server disables it", getLogLocally());
     }
 }


### PR DESCRIPTION
## Summary
- Server response to `/users.json` with `verbose_logging=false` could disable local logging even when the developer explicitly set `io_teak_force_debug_output=true` in Android resources
- `setLogPreferences()` now preserves local logging when forced by the resource flag, while keeping remote logging and server-initiated local logging fully server-controlled
- Mirrors fix for the same bug found in the iOS SDK

## Test plan
- [x] `serverFalse_doesNotOverrideForceDebugOutputResource` — resource flag survives server false
- [x] `serverTrue_enablesLogging` — server can still enable logging
- [x] `serverFalse_disablesRemoteLogging` — server can turn off remote logging it previously enabled
- [x] `serverFalse_disablesPreviouslyEnabledLocalLogging` — server can turn off local logging it previously enabled
- [x] Full debug unit test suite passes (29 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)