### PR TITLE
Fix crash when billing library is absent

### DIFF
--- a/src/main/java/io/teak/sdk/DefaultObjectFactory.java
+++ b/src/main/java/io/teak/sdk/DefaultObjectFactory.java
@@ -112,13 +112,12 @@ public class DefaultObjectFactory implements IObjectFactory {
         } else {
             try {
                 // Check if the billing library is present at all
-                Class.forName("com.android.billingclient.api.BillingClient");
+                Class<?> billingClientClass = Class.forName("com.android.billingclient.api.BillingClient");
 
                 try {
                     // If the 'BillingClient.queryProductDetailsAsync' method is present
                     // this is Google Play Billing v5 so use that instead.
-                    Class<?> gpbv5 = Class.forName("com.android.billingclient.api.BillingClient");
-                    gpbv5.getMethod("queryProductDetailsAsync");
+                    billingClientClass.getMethod("queryProductDetailsAsync");
                     clazz = Class.forName("io.teak.sdk.store.GooglePlayBillingV5");
                 } catch (NoSuchMethodException ignored) {
                 }

--- a/src/main/java/io/teak/sdk/DefaultObjectFactory.java
+++ b/src/main/java/io/teak/sdk/DefaultObjectFactory.java
@@ -75,7 +75,7 @@ public class DefaultObjectFactory implements IObjectFactory {
 
     ///// Helpers
 
-    private IStore createStore(@NonNull Context context) {
+    static IStore createStore(@NonNull Context context) {
         // If automatic purchase collection is disabled, just return null
         //
         // Note that we cannot use TeakConfiguration here because this happens before it is initialized.

--- a/src/main/java/io/teak/sdk/DefaultObjectFactory.java
+++ b/src/main/java/io/teak/sdk/DefaultObjectFactory.java
@@ -106,7 +106,7 @@ public class DefaultObjectFactory implements IObjectFactory {
             try {
                 Class.forName("com.amazon.device.iap.PurchasingListener");
                 clazz = Class.forName("io.teak.sdk.store.Amazon");
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 Teak.log.exception(e);
             }
         } else {

--- a/src/main/java/io/teak/sdk/DefaultObjectFactory.java
+++ b/src/main/java/io/teak/sdk/DefaultObjectFactory.java
@@ -111,24 +111,24 @@ public class DefaultObjectFactory implements IObjectFactory {
             }
         } else {
             try {
-                // If the 'BillingClient.queryProductDetailsAsync' method is present
-                // this is Google Play Billing v5 so use that instead.
-                Class<?> gpbv5 = Class.forName("com.android.billingclient.api.BillingClient");
-                gpbv5.getMethod("queryProductDetailsAsync");
-                clazz = Class.forName("io.teak.sdk.store.GooglePlayBillingV5");
-            } catch (NoSuchMethodException ignored) {
+                // Check if the billing library is present at all
+                Class.forName("com.android.billingclient.api.BillingClient");
 
-            } catch (Exception e) {
-                Teak.log.exception(e);
-            }
-
-            if (clazz == null) {
                 try {
+                    // If the 'BillingClient.queryProductDetailsAsync' method is present
+                    // this is Google Play Billing v5 so use that instead.
+                    Class<?> gpbv5 = Class.forName("com.android.billingclient.api.BillingClient");
+                    gpbv5.getMethod("queryProductDetailsAsync");
+                    clazz = Class.forName("io.teak.sdk.store.GooglePlayBillingV5");
+                } catch (NoSuchMethodException ignored) {
+                }
+
+                if (clazz == null) {
                     // Default to Billing v4
                     clazz = Class.forName("io.teak.sdk.store.GooglePlayBillingV4");
-                } catch (Exception e) {
-                    Teak.log.exception(e);
                 }
+            } catch (Throwable e) {
+                Teak.log.exception(e);
             }
         }
 

--- a/test_app/app/src/test/java/io/teak/sdk/CreateStoreTest.java
+++ b/test_app/app/src/test/java/io/teak/sdk/CreateStoreTest.java
@@ -1,0 +1,83 @@
+package io.teak.sdk;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import io.teak.sdk.store.IStore;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CreateStoreTest {
+
+    private Context createMockContext(Boolean noAutoTrack) throws PackageManager.NameNotFoundException {
+        Context context = mock(Context.class);
+        PackageManager packageManager = mock(PackageManager.class);
+        when(context.getPackageManager()).thenReturn(packageManager);
+        when(context.getPackageName()).thenReturn("io.teak.app.test");
+        when(context.getApplicationContext()).thenReturn(context);
+
+        ApplicationInfo appInfo = new ApplicationInfo();
+        Bundle metaData = mock(Bundle.class);
+        if (noAutoTrack != null) {
+            when(metaData.getBoolean("io_teak_no_auto_track_purchase", false)).thenReturn(noAutoTrack);
+        }
+        appInfo.metaData = metaData;
+        when(packageManager.getApplicationInfo("io.teak.app.test", PackageManager.GET_META_DATA))
+            .thenReturn(appInfo);
+
+        return context;
+    }
+
+    @Test
+    public void autoTrackDisabled_returnsNull() throws Exception {
+        Context context = createMockContext(true);
+        IStore store = DefaultObjectFactory.createStore(context);
+        assertNull("Store should be null when auto-track purchase is disabled", store);
+    }
+
+    @Test
+    public void nullPackageManager_returnsNull() throws Exception {
+        Context context = mock(Context.class);
+        when(context.getPackageManager()).thenReturn(null);
+        when(context.getPackageName()).thenReturn("io.teak.app.test");
+
+        IStore store = DefaultObjectFactory.createStore(context);
+        assertNull("Store should be null when PackageManager is null", store);
+    }
+
+    @Test
+    public void nullBundleId_returnsNull() throws Exception {
+        Context context = mock(Context.class);
+        PackageManager packageManager = mock(PackageManager.class);
+        when(context.getPackageManager()).thenReturn(packageManager);
+        when(context.getPackageName()).thenReturn(null);
+
+        IStore store = DefaultObjectFactory.createStore(context);
+        assertNull("Store should be null when bundle ID is null", store);
+    }
+
+    @Test
+    public void noMetadataKey_proceedsNormally() throws Exception {
+        Context context = createMockContext(null);
+        IStore store = DefaultObjectFactory.createStore(context);
+        // Billing library is on the test classpath, so store should be created
+        assertNotNull("Store should be created when billing library is present and auto-track is not disabled", store);
+    }
+
+    @Test
+    public void autoTrackExplicitlyEnabled_proceedsNormally() throws Exception {
+        Context context = createMockContext(false);
+        IStore store = DefaultObjectFactory.createStore(context);
+        assertNotNull("Store should be created when auto-track is explicitly enabled", store);
+    }
+}


### PR DESCRIPTION
## Summary
- Guard Google Play store class loading behind a `BillingClient` presence check before attempting to load `GooglePlayBillingV4`/`V5`
- Catch `Throwable` instead of `Exception` on both Google Play and Amazon store paths to handle `NoClassDefFoundError`
- Make `createStore` static/package-private and add unit tests

## Root cause
When a game doesn't include the Google Play Billing library, the V5 detection fails with `ClassNotFoundException` (caught), but the V4 fallback loads `GooglePlayBillingV4` from our AAR — which triggers `NoClassDefFoundError` when its billing library imports can't be resolved. `NoClassDefFoundError` is an `Error`, not an `Exception`, so `catch (Exception e)` didn't catch it.

## Test plan
- [x] Unit tests for `createStore()` — auto-track disabled, null guards, normal path (5 tests, all passing)
- [x] Full test suite passes (35 tests)
- [ ] Manual verification on device without billing library (blocked by `compileOnly` leaking through project dependencies — only reproducible with published AAR consumption or R8-enabled builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)