### PR TITLE
C-700: claim_mode opt-in, click payload, enum extension

### DIFF
--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,3 +1,3 @@
 new:
-  - "Added ``io_teak_claim_mode`` string resource. When set, the SDK declares its claim mode on every reward click and warns at init if the configured value isn't in the game's ``supported_claim_modes``. Defaults to ``legacy``."
+  - "Added ``io_teak_reward_claim_mode`` string resource. When set, the SDK declares its claim mode on every reward click and warns at init if the configured value isn't in the game's ``supported_claim_modes``. Defaults to ``legacy``."
   - "``TeakNotification.Reward`` now exposes ``PLAYER_INELIGIBLE`` (-7), ``NO_REWARD_AVAILABLE`` (-8), and ``CLAIM_MODE_UNSUPPORTED`` (-9) status values for the new server reward states."

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,0 +1,3 @@
+new:
+  - "Added ``io_teak_claim_mode`` string resource. When set, the SDK declares its claim mode on every reward click and warns at init if the configured value isn't in the game's ``supported_claim_modes``. Defaults to ``legacy``."
+  - "``TeakNotification.Reward`` now exposes ``PLAYER_INELIGIBLE`` (-7), ``NO_REWARD_AVAILABLE`` (-8), and ``CLAIM_MODE_UNSUPPORTED`` (-9) status values for the new server reward states."

--- a/src/main/java/io/teak/sdk/TeakNotification.java
+++ b/src/main/java/io/teak/sdk/TeakNotification.java
@@ -112,6 +112,21 @@ public class TeakNotification implements Unobfuscable {
         public static final int INVALID_POST = -6;
 
         /**
+         * The clicking user is not eligible to claim this reward.
+         */
+        public static final int PLAYER_INELIGIBLE = -7;
+
+        /**
+         * No reward is currently available for this user from this notification.
+         */
+        public static final int NO_REWARD_AVAILABLE = -8;
+
+        /**
+         * The configured claim mode is not supported by this game.
+         */
+        public static final int CLAIM_MODE_UNSUPPORTED = -9;
+
+        /**
          * Status of this reward.
          *
          * One of the following status codes:
@@ -123,6 +138,9 @@ public class TeakNotification implements Unobfuscable {
          * {@link Reward#EXCEED_MAX_CLICKS_FOR_DAY}
          * {@link Reward#EXPIRED}
          * {@link Reward#INVALID_POST}
+         * {@link Reward#PLAYER_INELIGIBLE}
+         * {@link Reward#NO_REWARD_AVAILABLE}
+         * {@link Reward#CLAIM_MODE_UNSUPPORTED}
          *
          * If status is {@link Reward#GRANT_REWARD}, the 'reward' field will contain the reward that should be granted.
          */
@@ -153,6 +171,12 @@ public class TeakNotification implements Unobfuscable {
                 status = EXPIRED;
             } else if (INVALID_POST_STRING.equals(statusString)) {
                 status = INVALID_POST;
+            } else if (PLAYER_INELIGIBLE_STRING.equals(statusString)) {
+                status = PLAYER_INELIGIBLE;
+            } else if (NO_REWARD_AVAILABLE_STRING.equals(statusString)) {
+                status = NO_REWARD_AVAILABLE;
+            } else if (CLAIM_MODE_UNSUPPORTED_STRING.equals(statusString)) {
+                status = CLAIM_MODE_UNSUPPORTED;
             } else {
                 status = UNKNOWN;
             }
@@ -171,6 +195,9 @@ public class TeakNotification implements Unobfuscable {
         private static final String EXCEED_MAX_CLICKS_FOR_DAY_STRING = "exceed_max_clicks_for_day";
         private static final String EXPIRED_STRING = "expired";
         private static final String INVALID_POST_STRING = "invalid_post";
+        private static final String PLAYER_INELIGIBLE_STRING = "player_ineligible";
+        private static final String NO_REWARD_AVAILABLE_STRING = "no_reward_available";
+        private static final String CLAIM_MODE_UNSUPPORTED_STRING = "claim_mode_unsupported";
 
         /**
          * @return A {@link Future} which will contain the reward that should be granted, or <code>null</code> if there is no associated reward.
@@ -205,9 +232,11 @@ public class TeakNotification implements Unobfuscable {
 
                 try {
                     // https://rewards.gocarrot.com/<<teak_reward_id>>/clicks?clicking_user_id=<<your_user_id>>
-                    //String requestBody = "clicking_user_id=" + URLEncoder.encode(session.userId(), "UTF-8");
+                    // String requestBody = "clicking_user_id=" + URLEncoder.encode(session.userId(), "UTF-8");
+                    final TeakConfiguration teakConfiguration = TeakConfiguration.get();
                     HashMap<String, Object> payload = new HashMap<>();
                     payload.put("clicking_user_id", session.userId());
+                    payload.put("claim_mode", teakConfiguration.appConfiguration.claimMode);
 
                     Request.submit("rewards.gocarrot.com", "/" + teakRewardId + "/clicks", payload, session,
                         (responseCode, responseBody) -> {

--- a/src/main/java/io/teak/sdk/configuration/AppConfiguration.java
+++ b/src/main/java/io/teak/sdk/configuration/AppConfiguration.java
@@ -49,6 +49,8 @@ public class AppConfiguration {
     public final Set<String> urlSchemes;
     @SuppressWarnings("WeakerAccess")
     public final boolean sdk5Behaviors;
+    @SuppressWarnings("WeakerAccess")
+    public final String claimMode;
 
     @SuppressWarnings("WeakerAccess")
     public static final String TEAK_API_KEY_RESOURCE = "io_teak_api_key";
@@ -60,6 +62,11 @@ public class AppConfiguration {
     public static final String TEAK_TRACE_LOG_RESOURCE = "io_teak_log_trace";
     @SuppressWarnings("WeakerAccess")
     public static final String TEAK_SDK_5_BEHAVIORS = "io_teak_sdk5_behaviors";
+    @SuppressWarnings("WeakerAccess")
+    public static final String TEAK_CLAIM_MODE_RESOURCE = "io_teak_claim_mode";
+
+    @SuppressWarnings("WeakerAccess")
+    public static final String DefaultClaimMode = "legacy";
 
     @SuppressWarnings("WeakerAccess")
     public static final String GooglePlayStoreId = "google_play";
@@ -182,6 +189,12 @@ public class AppConfiguration {
             final Boolean sdk5Behaviors = androidResources.getTeakBoolResource(TEAK_SDK_5_BEHAVIORS, true);
             this.sdk5Behaviors = sdk5Behaviors != null ? sdk5Behaviors : true;
         }
+
+        // Claim mode
+        {
+            final String configuredClaimMode = androidResources.getTeakStringResource(TEAK_CLAIM_MODE_RESOURCE);
+            this.claimMode = (configuredClaimMode == null || configuredClaimMode.trim().isEmpty()) ? DefaultClaimMode : configuredClaimMode;
+        }
     }
 
     @SuppressWarnings("deprecation")
@@ -204,6 +217,7 @@ public class AppConfiguration {
         ret.put("targetSdkVersion", this.targetSdkVersion);
         ret.put("traceLog", this.traceLog);
         ret.put("sdk5Behaviors", this.sdk5Behaviors);
+        ret.put("claimMode", this.claimMode);
         return ret;
     }
 

--- a/src/main/java/io/teak/sdk/configuration/AppConfiguration.java
+++ b/src/main/java/io/teak/sdk/configuration/AppConfiguration.java
@@ -63,7 +63,7 @@ public class AppConfiguration {
     @SuppressWarnings("WeakerAccess")
     public static final String TEAK_SDK_5_BEHAVIORS = "io_teak_sdk5_behaviors";
     @SuppressWarnings("WeakerAccess")
-    public static final String TEAK_CLAIM_MODE_RESOURCE = "io_teak_claim_mode";
+    public static final String TEAK_CLAIM_MODE_RESOURCE = "io_teak_reward_claim_mode";
 
     @SuppressWarnings("WeakerAccess")
     public static final String DefaultClaimMode = "legacy";

--- a/src/main/java/io/teak/sdk/configuration/RemoteConfiguration.java
+++ b/src/main/java/io/teak/sdk/configuration/RemoteConfiguration.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import io.teak.sdk.IntegrationChecker;
 import io.teak.sdk.Request;
 import io.teak.sdk.Teak;
 import io.teak.sdk.TeakConfiguration;
@@ -18,6 +19,7 @@ import io.teak.sdk.event.DeepLinksReadyEvent;
 import io.teak.sdk.event.RemoteConfigurationEvent;
 import io.teak.sdk.io.AndroidResources;
 import io.teak.sdk.io.DefaultAndroidResources;
+import io.teak.sdk.json.JSONArray;
 import io.teak.sdk.json.JSONObject;
 
 public class RemoteConfiguration {
@@ -237,6 +239,10 @@ public class RemoteConfiguration {
                                 categories,
                                 false);
 
+                            // Warn if the configured claim_mode isn't in the game's supported_claim_modes.
+                            warnIfClaimModeUnsupported(teakConfiguration.appConfiguration.claimMode,
+                                response.optJSONArray("supported_claim_modes"));
+
                             Teak.log.i("configuration.remote", configuration.toHash());
                             TeakEvent.postEvent(new RemoteConfigurationEvent(configuration));
                         } catch (Exception e) {
@@ -267,6 +273,30 @@ public class RemoteConfiguration {
         return RemoteConfiguration.defaultHostname;
     }
     // endregion
+
+    private static void warnIfClaimModeUnsupported(@NonNull String configuredClaimMode, @Nullable JSONArray supportedClaimModes) {
+        if (supportedClaimModes == null) {
+            return;
+        }
+
+        boolean found = false;
+        for (int i = 0; i < supportedClaimModes.length(); i++) {
+            final Object entry = supportedClaimModes.opt(i);
+            if (entry instanceof String && configuredClaimMode.equals(entry)) {
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            final HashMap<String, Object> data = new HashMap<>();
+            data.put("configured_claim_mode", configuredClaimMode);
+            data.put("supported_claim_modes", supportedClaimModes.toString());
+            Teak.log.w(IntegrationChecker.LOG_TAG,
+                "Configured " + AppConfiguration.TEAK_CLAIM_MODE_RESOURCE + " '" + configuredClaimMode + "' is not in this game's supported_claim_modes. Reward claims may fail with claim_mode_unsupported.",
+                data);
+        }
+    }
 
     private Map<String, Object> toHash() {
         HashMap<String, Object> ret = new HashMap<>();

--- a/src/main/java/io/teak/sdk/configuration/RemoteConfiguration.java
+++ b/src/main/java/io/teak/sdk/configuration/RemoteConfiguration.java
@@ -275,27 +275,16 @@ public class RemoteConfiguration {
     // endregion
 
     private static void warnIfClaimModeUnsupported(@NonNull String configuredClaimMode, @Nullable JSONArray supportedClaimModes) {
-        if (supportedClaimModes == null) {
+        if (supportedClaimModes == null || supportedClaimModes.toList().contains(configuredClaimMode)) {
             return;
         }
 
-        boolean found = false;
-        for (int i = 0; i < supportedClaimModes.length(); i++) {
-            final Object entry = supportedClaimModes.opt(i);
-            if (entry instanceof String && configuredClaimMode.equals(entry)) {
-                found = true;
-                break;
-            }
-        }
-
-        if (!found) {
-            final HashMap<String, Object> data = new HashMap<>();
-            data.put("configured_claim_mode", configuredClaimMode);
-            data.put("supported_claim_modes", supportedClaimModes.toString());
-            Teak.log.w(IntegrationChecker.LOG_TAG,
-                "Configured " + AppConfiguration.TEAK_CLAIM_MODE_RESOURCE + " '" + configuredClaimMode + "' is not in this game's supported_claim_modes. Reward claims may fail with claim_mode_unsupported.",
-                data);
-        }
+        final HashMap<String, Object> data = new HashMap<>();
+        data.put("configured_claim_mode", configuredClaimMode);
+        data.put("supported_claim_modes", supportedClaimModes.toString());
+        Teak.log.w(IntegrationChecker.LOG_TAG,
+            "Configured " + AppConfiguration.TEAK_CLAIM_MODE_RESOURCE + " '" + configuredClaimMode + "' is not in this game's supported_claim_modes. Reward claims may fail with claim_mode_unsupported.",
+            data);
     }
 
     private Map<String, Object> toHash() {

--- a/test_app/app/src/test/java/io/teak/app/test/ClaimModeTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/ClaimModeTest.java
@@ -62,18 +62,18 @@ public class ClaimModeTest extends TeakUnitTest {
 
     @Test
     public void claimMode_readsConfiguredValue() throws Exception {
-        when(androidResources.getStringResource(AppConfiguration.TEAK_CLAIM_MODE_RESOURCE)).thenReturn("server_authoritative");
+        when(androidResources.getStringResource(AppConfiguration.TEAK_CLAIM_MODE_RESOURCE)).thenReturn("client_jwt");
         reinitializeWithCurrentMocks();
 
-        assertEquals("server_authoritative", TeakConfiguration.get().appConfiguration.claimMode);
+        assertEquals("client_jwt", TeakConfiguration.get().appConfiguration.claimMode);
     }
 
     @Test
     public void claimMode_appearsInToMap() throws Exception {
-        when(androidResources.getStringResource(AppConfiguration.TEAK_CLAIM_MODE_RESOURCE)).thenReturn("server_authoritative");
+        when(androidResources.getStringResource(AppConfiguration.TEAK_CLAIM_MODE_RESOURCE)).thenReturn("client_jwt");
         reinitializeWithCurrentMocks();
 
-        assertEquals("server_authoritative",
+        assertEquals("client_jwt",
             TeakConfiguration.get().appConfiguration.toMap().get("claimMode"));
     }
 

--- a/test_app/app/src/test/java/io/teak/app/test/ClaimModeTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/ClaimModeTest.java
@@ -1,0 +1,122 @@
+package io.teak.app.test;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+
+import io.teak.sdk.TeakConfiguration;
+import io.teak.sdk.TeakNotification;
+import io.teak.sdk.configuration.AppConfiguration;
+import io.teak.sdk.json.JSONObject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClaimModeTest extends TeakUnitTest {
+
+    private void reinitializeWithCurrentMocks() throws NoSuchFieldException, IllegalAccessException {
+        TestHelpers.resetTeakConfiguration();
+        if (!TeakConfiguration.initialize(context, objectFactory)) {
+            throw new IllegalArgumentException("TeakConfiguration re-initialization failed.");
+        }
+    }
+
+    // The Reward(JSONObject) constructor is package-private. Tests live in io.teak.app.test,
+    // so reach through reflection. This mirrors how DebugConfigurationTest pokes at Log internals.
+    private int rewardStatusForServerString(String serverStatus) throws Exception {
+        final JSONObject body = new JSONObject();
+        body.put("status", serverStatus);
+
+        final Constructor<TeakNotification.Reward> ctor =
+            TeakNotification.Reward.class.getDeclaredConstructor(JSONObject.class);
+        ctor.setAccessible(true);
+        final TeakNotification.Reward reward = ctor.newInstance(body);
+
+        final Field statusField = TeakNotification.Reward.class.getDeclaredField("status");
+        return (int) statusField.get(reward);
+    }
+
+    // --- AppConfiguration.claimMode ---
+
+    @Test
+    public void claimMode_defaultsToLegacy_whenResourceAbsent() {
+        // androidResources is unmocked for io_teak_claim_mode in TeakUnitTest -> returns null.
+        assertEquals(AppConfiguration.DefaultClaimMode,
+            TeakConfiguration.get().appConfiguration.claimMode);
+        assertEquals("legacy", TeakConfiguration.get().appConfiguration.claimMode);
+    }
+
+    @Test
+    public void claimMode_defaultsToLegacy_whenResourceEmpty() throws Exception {
+        when(androidResources.getStringResource(AppConfiguration.TEAK_CLAIM_MODE_RESOURCE)).thenReturn("   ");
+        reinitializeWithCurrentMocks();
+
+        assertEquals(AppConfiguration.DefaultClaimMode,
+            TeakConfiguration.get().appConfiguration.claimMode);
+    }
+
+    @Test
+    public void claimMode_readsConfiguredValue() throws Exception {
+        when(androidResources.getStringResource(AppConfiguration.TEAK_CLAIM_MODE_RESOURCE)).thenReturn("server_authoritative");
+        reinitializeWithCurrentMocks();
+
+        assertEquals("server_authoritative", TeakConfiguration.get().appConfiguration.claimMode);
+    }
+
+    @Test
+    public void claimMode_appearsInToMap() throws Exception {
+        when(androidResources.getStringResource(AppConfiguration.TEAK_CLAIM_MODE_RESOURCE)).thenReturn("server_authoritative");
+        reinitializeWithCurrentMocks();
+
+        assertEquals("server_authoritative",
+            TeakConfiguration.get().appConfiguration.toMap().get("claimMode"));
+    }
+
+    // --- Reward.Status string-to-enum mapping for new values ---
+
+    @Test
+    public void rewardStatus_mapsPlayerIneligible() throws Exception {
+        assertEquals(TeakNotification.Reward.PLAYER_INELIGIBLE, rewardStatusForServerString("player_ineligible"));
+    }
+
+    @Test
+    public void rewardStatus_mapsNoRewardAvailable() throws Exception {
+        assertEquals(TeakNotification.Reward.NO_REWARD_AVAILABLE, rewardStatusForServerString("no_reward_available"));
+    }
+
+    @Test
+    public void rewardStatus_mapsClaimModeUnsupported() throws Exception {
+        assertEquals(TeakNotification.Reward.CLAIM_MODE_UNSUPPORTED, rewardStatusForServerString("claim_mode_unsupported"));
+    }
+
+    @Test
+    public void rewardStatus_unknownStringFallsBackToUnknown() throws Exception {
+        assertEquals(TeakNotification.Reward.UNKNOWN, rewardStatusForServerString("something_brand_new"));
+    }
+
+    @Test
+    public void rewardStatus_existingMappingsStillWork() throws Exception {
+        // Sanity: the new branches do not break legacy strings.
+        assertEquals(TeakNotification.Reward.GRANT_REWARD, rewardStatusForServerString("grant_reward"));
+        assertEquals(TeakNotification.Reward.SELF_CLICK, rewardStatusForServerString("self_click"));
+    }
+
+    // --- Enum constants are distinct ---
+
+    @Test
+    public void rewardStatus_newConstantsHaveExpectedValues() {
+        assertEquals(-7, TeakNotification.Reward.PLAYER_INELIGIBLE);
+        assertEquals(-8, TeakNotification.Reward.NO_REWARD_AVAILABLE);
+        assertEquals(-9, TeakNotification.Reward.CLAIM_MODE_UNSUPPORTED);
+
+        // And they're distinct from the legacy values
+        assertNotEquals(TeakNotification.Reward.PLAYER_INELIGIBLE, TeakNotification.Reward.INVALID_POST);
+        assertNotEquals(TeakNotification.Reward.NO_REWARD_AVAILABLE, TeakNotification.Reward.INVALID_POST);
+        assertNotEquals(TeakNotification.Reward.CLAIM_MODE_UNSUPPORTED, TeakNotification.Reward.INVALID_POST);
+    }
+}

--- a/test_app/app/src/test/java/io/teak/app/test/ClaimModeTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/ClaimModeTest.java
@@ -45,7 +45,7 @@ public class ClaimModeTest extends TeakUnitTest {
 
     @Test
     public void claimMode_defaultsToLegacy_whenResourceAbsent() {
-        // androidResources is unmocked for io_teak_claim_mode in TeakUnitTest -> returns null.
+        // androidResources is unmocked for io_teak_reward_claim_mode in TeakUnitTest -> returns null.
         assertEquals(AppConfiguration.DefaultClaimMode,
             TeakConfiguration.get().appConfiguration.claimMode);
         assertEquals("legacy", TeakConfiguration.get().appConfiguration.claimMode);


### PR DESCRIPTION
Closes https://linear.app/teakio/issue/C-700/android-sdk-claim-mode-opt-in-click-payload-enum-extension

## Summary

Wires the Android SDK's claim mode into reward click payloads and declares it at init. Parallels iOS C-697.

* `AppConfiguration` reads `io_teak_claim_mode` (default `"legacy"`).
* `TeakNotification.Reward.rewardFromRewardId()` puts `claim_mode` on every click payload — explicit on every 4.4.x request, even for legacy-opted apps.
* `TeakNotification.Reward` gains `PLAYER_INELIGIBLE` (-7), `NO_REWARD_AVAILABLE` (-8), `CLAIM_MODE_UNSUPPORTED` (-9), and the matching string-to-enum mappings (`player_ineligible`, `no_reward_available`, `claim_mode_unsupported`).
* `RemoteConfiguration` warns at init (after `settings.json` fetch) if the configured `claim_mode` isn't in the response's `supported_claim_modes`.

## Test plan

* `./gradlew assemble` — green
* `./org_json_check`, `./check_thread_use` — green
* `(cd test_app && ./gradlew testDebugUnitTest)` — full suite green, including 10 new `ClaimModeTest` tests covering: default-when-absent, default-when-empty, configured-value, `toMap` exposure, the three new status mappings, fallback to `UNKNOWN`, legacy mappings unchanged, and constant numeric values.

## Readers left behind

* Click-time JWT handling is out of scope here (tracked separately in C-701).
* The init-time warning logs but does not block init. That's intentional — the legacy default ships with no behavior change for games that don't opt in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)