### PR TITLE
C-702: Android session-start /claims sweep

### DIFF
--- a/src/main/java/io/teak/sdk/Teak.java
+++ b/src/main/java/io/teak/sdk/Teak.java
@@ -1717,18 +1717,18 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
         /**
          * Server-bookkeeping and raw-attribution wire fields stripped from the host-
          * facing payload. The eleven attribution keys are surfaced as discrete top-level
-         * keys via {@link #attribution}; the raw blob and timing fields aren't part of
-         * the documented public surface. {@code teak_reward_id} is stripped to match
-         * legacy {@code TeakOnReward} semantics — only the attribution
+         * keys via {@link #attribution}; the raw {@code session_attribution} blob isn't
+         * part of the documented public surface. {@code teak_reward_id} is stripped to
+         * match legacy {@code TeakOnReward} semantics — only the attribution
          * {@code teakRewardId} surfaces here; host games that need the server-
          * authoritative grant id correlate by {@code event_id} against the earlier
-         * {@link RewardJwtIssuedEvent} / {@link RewardClaimPendingEvent}.
+         * {@link RewardJwtIssuedEvent} / {@link RewardClaimPendingEvent}. {@code created_at}
+         * and {@code completed_at} are passed through as documented timing fields,
+         * matching iOS post-C-724 and JS post-C-725.
          */
         private static final String[] STRIP_KEYS = {
             "teak_reward_id",
             "session_attribution",
-            "created_at",
-            "completed_at",
         };
 
         /// @cond hide_from_doxygen

--- a/src/main/java/io/teak/sdk/Teak.java
+++ b/src/main/java/io/teak/sdk/Teak.java
@@ -138,7 +138,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
         try {
             if (intent != null && intent.getData() != null) {
                 final Uri intentData = intent.getData();
-                if(intentData.isHierarchical()) {
+                if (intentData.isHierarchical()) {
                     if (intentData.getBooleanQueryParameter("teak_log", false)) {
                         Teak.forceDebug = true;
                     }
@@ -155,14 +155,14 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
                     if (intentData.getBooleanQueryParameter("teak_strict_mode", false)) {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                             StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
-                                                       .detectNonSdkApiUsage()
-                                                       .penaltyLog()
-                                                       .build());
+                                    .detectNonSdkApiUsage()
+                                    .penaltyLog()
+                                    .build());
                         }
                     }
                 }
             }
-        } catch(Exception e) {
+        } catch (Exception e) {
             android.util.Log.e(LOG_TAG, android.util.Log.getStackTraceString(e));
         }
 
@@ -436,7 +436,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
     public static void requestNotificationPermissions() {
         Teak.log.i("Teak.requestNotificationPermissions", "Hello");
 
-        if(Instance != null) {
+        if (Instance != null) {
             asyncExecutor.submit(() -> Instance.requestNotificationPermissions());
         }
     }
@@ -510,7 +510,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
             SMS("sms"),                    ///< SMS channel
             Invalid("invalid");            ///< Invalid channel, will be ignored if used
 
-            //public static final Integer length = 1 + Invalid.ordinal();
+            // public static final Integer length = 1 + Invalid.ordinal();
 
             public final String name;
 
@@ -541,7 +541,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
             Absent("absent"),
             Unknown("unknown");
 
-            //public static final Integer length = 1 + Absent.ordinal();
+            // public static final Integer length = 1 + Absent.ordinal();
 
             public final String name;
 
@@ -1266,7 +1266,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
         protected AttributedLaunchData(@Nullable final Uri shortLink, @NonNull Uri deepLink) {
             super(shortLink);
 
-            if(deepLink.isOpaque()) {
+            if (deepLink.isOpaque()) {
                 this.scheduleName = this.scheduleId = this.creativeName = this.creativeId = this.rewardId = this.channelName = this.optOutCategory = null;
                 this.deepLink = deepLink;
                 return;
@@ -1306,7 +1306,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
             this.rewardId = Helpers.newIfNotOld(oldLaunchData.rewardId, newLaunchData.rewardId);
             this.channelName = Helpers.newIfNotOld(oldLaunchData.channelName, newLaunchData.channelName);
             this.deepLink = updatedDeepLink;
-            if(updatedDeepLink.isHierarchical()) {
+            if (updatedDeepLink.isHierarchical()) {
                 this.optOutCategory = Helpers.newIfNotOld(oldLaunchData.optOutCategory,
                     updatedDeepLink.getQueryParameter("teak_opt_out_category") != null ? updatedDeepLink.getQueryParameter("teak_opt_out_category") : "teak");
             } else {
@@ -1332,7 +1332,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
             // Put the URI and any query parameters that start with 'teak_' into 'deep_link'
             if (this.deepLink != null) {
                 map.put("deep_link", this.deepLink.toString());
-                if(this.deepLink.isHierarchical()) {
+                if (this.deepLink.isHierarchical()) {
                     for (final String name : this.deepLink.getQueryParameterNames()) {
                         if (name.startsWith("teak_")) {
                             final List<String> values = this.deepLink.getQueryParameters(name);
@@ -1406,7 +1406,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
          */
         protected NotificationLaunchData(@NonNull final NotificationLaunchData oldLaunchData, @NonNull Uri updatedDeepLink) {
             super(oldLaunchData, updatedDeepLink);
-            if(updatedDeepLink.isHierarchical()) {
+            if (updatedDeepLink.isHierarchical()) {
                 this.sourceSendId = Helpers.newIfNotOld(oldLaunchData.sourceSendId, updatedDeepLink.getQueryParameter("teak_notif_id"));
             } else {
                 this.sourceSendId = oldLaunchData.sourceSendId;
@@ -1536,7 +1536,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
         public JSONObject toJSON() {
             final JSONObject json = new JSONObject();
             final ArrayList<JSONObject> categories = new ArrayList<JSONObject>();
-            for(Teak.Channel.Category category : this.remoteConfiguration.categories) {
+            for (Teak.Channel.Category category : this.remoteConfiguration.categories) {
                 categories.add(category.toJSON());
             }
 
@@ -1706,29 +1706,51 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
         @NonNull
         public final JSONObject reply;
 
+        /**
+         * Eleven-key attribution map for this claim, sourced from the originating click's
+         * launch data (click-time path) or the wire {@code session_attribution} blob
+         * (session-start sweep path). Both surfaces flow through one canonical shape.
+         */
+        @NonNull
+        private final Map<String, Object> attribution;
+
+        /**
+         * Server-bookkeeping and raw-attribution wire fields stripped from the host-
+         * facing payload. The eleven attribution keys are surfaced as discrete top-level
+         * keys via {@link #attribution}; the raw blob and timing fields aren't part of
+         * the documented public surface. {@code teak_reward_id} is stripped to match
+         * legacy {@code TeakOnReward} semantics — only the attribution
+         * {@code teakRewardId} surfaces here; host games that need the server-
+         * authoritative grant id correlate by {@code event_id} against the earlier
+         * {@link RewardJwtIssuedEvent} / {@link RewardClaimPendingEvent}.
+         */
+        private static final String[] STRIP_KEYS = {
+            "teak_reward_id",
+            "session_attribution",
+            "created_at",
+            "completed_at",
+        };
+
         /// @cond hide_from_doxygen
-        public RewardClaimResolvedEvent(@NonNull final AttributedLaunchData launchData,
+        public RewardClaimResolvedEvent(@NonNull final Map<String, Object> attribution,
             @NonNull final String eventId, @NonNull final JSONObject reply) {
-            super(launchData, null);
+            // Resolved events flatten attribution into discrete top-level keys via
+            // toJSON(); host games correlate via event_id, not the launchData object.
+            // The base Event class still requires a LaunchData; Unattributed is the
+            // sentinel for "no separate launchData object on this event".
+            super(LaunchData.Unattributed, null);
             this.eventId = eventId;
             this.reply = reply;
+            this.attribution = attribution;
         }
 
         @Override
         public JSONObject toJSON() {
-            final Map<String, Object> map = this.launchData.toMap();
+            final Map<String, Object> map = new java.util.HashMap<>(this.attribution);
             map.putAll(this.reply.toMap());
-            // The resolved-event surface matches the legacy TeakOnReward semantics: only
-            // teakRewardId (camelCase, launch-data attribution) is exposed. The snake_case
-            // teak_reward_id from the wire reply is stripped here. Host games that need the
-            // server-authoritative grant id correlate by event_id against the earlier
-            // RewardJwtIssued / RewardClaimPending events, which DO carry teak_reward_id.
-            map.remove("teak_reward_id");
-            // The raw session_attribution blob is stripped because the eleven-key
-            // attribution it carries is already surfaced as discrete top-level keys via
-            // launchData.toMap() above. Hosts read those keys directly off the JSON
-            // payload; the encoded blob is not part of the host-facing surface.
-            map.remove("session_attribution");
+            for (String k : STRIP_KEYS) {
+                map.remove(k);
+            }
             map.put("event_id", this.eventId);
             // Cross-SDK always-present contract for the eleven attribution keys: unset
             // values must arrive as JSON null on the host-facing surface, matching iOS

--- a/src/main/java/io/teak/sdk/core/DefaultClaimRequestSender.java
+++ b/src/main/java/io/teak/sdk/core/DefaultClaimRequestSender.java
@@ -42,17 +42,32 @@ class DefaultClaimRequestSender implements RewardClaimManager.ClaimRequestSender
             (responseCode, responseBody) -> handler.onReply(responseCode, responseBody));
     }
 
+    @Override
+    public void sendSweep(@NonNull String teakAppId, @NonNull String clickingUserId,
+        @NonNull RewardClaimManager.ReplyHandler handler) {
+        final String endpoint = "/claims?" + sweepQueryString(teakAppId, clickingUserId);
+        Request.submit(HOSTNAME, "GET", endpoint, new HashMap<>(), Session.NullSession,
+            (responseCode, responseBody) -> handler.onReply(responseCode, responseBody));
+    }
+
     @NonNull
     private static String queryString(@NonNull String eventId, @NonNull String teakAppId,
         @NonNull String clickingUserId) {
         try {
-            return "teak_app_id=" + URLEncoder.encode(teakAppId, "UTF-8")
-                + "&clicking_user_id=" + URLEncoder.encode(clickingUserId, "UTF-8")
-                + "&event_id=" + URLEncoder.encode(eventId, "UTF-8");
+            return "teak_app_id=" + URLEncoder.encode(teakAppId, "UTF-8") + "&clicking_user_id=" + URLEncoder.encode(clickingUserId, "UTF-8") + "&event_id=" + URLEncoder.encode(eventId, "UTF-8");
         } catch (UnsupportedEncodingException e) {
             Teak.log.exception(e);
-            return "teak_app_id=" + teakAppId + "&clicking_user_id=" + clickingUserId
-                + "&event_id=" + eventId;
+            return "teak_app_id=" + teakAppId + "&clicking_user_id=" + clickingUserId + "&event_id=" + eventId;
+        }
+    }
+
+    @NonNull
+    private static String sweepQueryString(@NonNull String teakAppId, @NonNull String clickingUserId) {
+        try {
+            return "teak_app_id=" + URLEncoder.encode(teakAppId, "UTF-8") + "&clicking_user_id=" + URLEncoder.encode(clickingUserId, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            Teak.log.exception(e);
+            return "teak_app_id=" + teakAppId + "&clicking_user_id=" + clickingUserId;
         }
     }
 }

--- a/src/main/java/io/teak/sdk/core/DefaultClaimRequestSender.java
+++ b/src/main/java/io/teak/sdk/core/DefaultClaimRequestSender.java
@@ -1,14 +1,12 @@
 package io.teak.sdk.core;
 
+import android.net.Uri;
 import androidx.annotation.NonNull;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 
 import io.teak.sdk.Request;
-import io.teak.sdk.Teak;
 
 /**
  * Production HTTP boundary for {@link RewardClaimManager}. Routes through {@link Request}
@@ -26,7 +24,13 @@ class DefaultClaimRequestSender implements RewardClaimManager.ClaimRequestSender
     @Override
     public void sendPoll(@NonNull String eventId, @NonNull String teakAppId,
         @NonNull String clickingUserId, @NonNull RewardClaimManager.ReplyHandler handler) {
-        final String endpoint = "/claim_status?" + queryString(eventId, teakAppId, clickingUserId);
+        final String endpoint = new Uri.Builder()
+                                    .path("/claim_status")
+                                    .appendQueryParameter("teak_app_id", teakAppId)
+                                    .appendQueryParameter("clicking_user_id", clickingUserId)
+                                    .appendQueryParameter("event_id", eventId)
+                                    .build()
+                                    .toString();
         Request.submit(HOSTNAME, "GET", endpoint, new HashMap<>(), Session.NullSession,
             (responseCode, responseBody) -> handler.onReply(responseCode, responseBody));
     }
@@ -45,29 +49,13 @@ class DefaultClaimRequestSender implements RewardClaimManager.ClaimRequestSender
     @Override
     public void sendSweep(@NonNull String teakAppId, @NonNull String clickingUserId,
         @NonNull RewardClaimManager.ReplyHandler handler) {
-        final String endpoint = "/claims?" + sweepQueryString(teakAppId, clickingUserId);
+        final String endpoint = new Uri.Builder()
+                                    .path("/claims")
+                                    .appendQueryParameter("teak_app_id", teakAppId)
+                                    .appendQueryParameter("clicking_user_id", clickingUserId)
+                                    .build()
+                                    .toString();
         Request.submit(HOSTNAME, "GET", endpoint, new HashMap<>(), Session.NullSession,
             (responseCode, responseBody) -> handler.onReply(responseCode, responseBody));
-    }
-
-    @NonNull
-    private static String queryString(@NonNull String eventId, @NonNull String teakAppId,
-        @NonNull String clickingUserId) {
-        try {
-            return "teak_app_id=" + URLEncoder.encode(teakAppId, "UTF-8") + "&clicking_user_id=" + URLEncoder.encode(clickingUserId, "UTF-8") + "&event_id=" + URLEncoder.encode(eventId, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            Teak.log.exception(e);
-            return "teak_app_id=" + teakAppId + "&clicking_user_id=" + clickingUserId + "&event_id=" + eventId;
-        }
-    }
-
-    @NonNull
-    private static String sweepQueryString(@NonNull String teakAppId, @NonNull String clickingUserId) {
-        try {
-            return "teak_app_id=" + URLEncoder.encode(teakAppId, "UTF-8") + "&clicking_user_id=" + URLEncoder.encode(clickingUserId, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            Teak.log.exception(e);
-            return "teak_app_id=" + teakAppId + "&clicking_user_id=" + clickingUserId;
-        }
     }
 }

--- a/src/main/java/io/teak/sdk/core/RewardClaim.java
+++ b/src/main/java/io/teak/sdk/core/RewardClaim.java
@@ -4,9 +4,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.lang.ref.WeakReference;
+import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 
-import io.teak.sdk.Teak;
 import io.teak.sdk.json.JSONObject;
 
 /**
@@ -15,16 +15,25 @@ import io.teak.sdk.json.JSONObject;
  * an Expiring→Active flicker (same Session instance after a brief background) keeps polling
  * alive, while a logout/login swap or post-Expired session change drops the entry on the
  * next stale-check site.
+ *
+ * <p>Attribution travels as the eleven-key flat-bag map (the canonical
+ * {@code session_attribution} shape) so click-time and session-start-sweep entries share
+ * one in-flight shape. Click-time callers flatten their launch-data once at start; sweep
+ * callers unpack the wire blob.
  */
 class RewardClaim {
     @NonNull
     final String eventId;
 
-    /** Reward id the click was originally fired against. May be null for legacy clicks. */
+    /**
+     * Reward id the click was originally fired against. May be null for legacy clicks.
+     */
     @Nullable
     final String teakRewardId;
 
-    /** Session that fired the click. Used to detect cross-session staleness. */
+    /**
+     * Session that fired the click. Used to detect cross-session staleness.
+     */
     @NonNull
     final WeakReference<Session> originatingSession;
 
@@ -35,30 +44,37 @@ class RewardClaim {
     @NonNull
     final String originatingClickingUserId;
 
-    /** Launch data attached to this click; null for direct-API claims with no attribution. */
-    @Nullable
-    final Teak.AttributedLaunchData launchData;
+    /**
+     * Eleven-key attribution map for this claim. Empty for direct-API claims with no
+     * attribution context. Always non-null so the resolved-event merge has a stable shape.
+     */
+    @NonNull
+    final Map<String, Object> attribution;
 
     int pollAttempt;
     int ackAttempt;
 
-    /** Set when a terminal (completed / failed) reply lands, before ack is fired. */
+    /**
+     * Set when a terminal (completed / failed) reply lands, before ack is fired.
+     */
     @Nullable
     JSONObject resolvedReply;
 
-    /** Outstanding scheduled work for cancellation on session-Expired. */
+    /**
+     * Outstanding scheduled work for cancellation on session-Expired.
+     */
     @Nullable
     ScheduledFuture<?> nextPollFuture;
     @Nullable
     ScheduledFuture<?> nextAckFuture;
 
     RewardClaim(@NonNull String eventId, @Nullable String teakRewardId,
-        @NonNull Session originatingSession, @Nullable Teak.AttributedLaunchData launchData) {
+        @NonNull Session originatingSession, @NonNull Map<String, Object> attribution) {
         this.eventId = eventId;
         this.teakRewardId = teakRewardId;
         this.originatingSession = new WeakReference<>(originatingSession);
         this.originatingClickingUserId = originatingSession.userId() == null ? "" : originatingSession.userId();
-        this.launchData = launchData;
+        this.attribution = attribution;
         this.pollAttempt = 0;
         this.ackAttempt = 0;
     }

--- a/src/main/java/io/teak/sdk/core/RewardClaimManager.java
+++ b/src/main/java/io/teak/sdk/core/RewardClaimManager.java
@@ -4,18 +4,19 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import io.teak.sdk.Teak;
 import io.teak.sdk.TeakConfiguration;
 import io.teak.sdk.TeakEvent;
 import io.teak.sdk.event.SessionStateEvent;
+import io.teak.sdk.json.JSONArray;
 import io.teak.sdk.json.JSONObject;
 
 /**
@@ -43,7 +44,9 @@ public class RewardClaimManager {
     public static final int DEFAULT_CEILING_MS = 30000;
     public static final int ACK_MAX_ATTEMPTS = 3;
 
-    /** Status strings the manager treats as terminal on a /claim_status reply. */
+    /**
+     * Status strings the manager treats as terminal on a /claim_status reply.
+     */
     static final String STATUS_COMPLETED = "completed";
     static final String STATUS_FAILED = "failed";
     static final String STATUS_PENDING = "pending";
@@ -64,6 +67,8 @@ public class RewardClaimManager {
             @NonNull String clickingUserId, @NonNull ReplyHandler handler);
         void sendAck(@NonNull String eventId, @NonNull String teakAppId,
             @NonNull String clickingUserId, @NonNull ReplyHandler handler);
+        void sendSweep(@NonNull String teakAppId, @NonNull String clickingUserId,
+            @NonNull ReplyHandler handler);
     }
 
     public interface ReplyHandler {
@@ -80,14 +85,18 @@ public class RewardClaimManager {
         }
     }
 
-    /** Test hook: number of in-flight claims at this moment. */
+    /**
+     * Test hook: number of in-flight claims at this moment.
+     */
     public int inFlightCount() {
         synchronized (inFlightLock) {
             return inFlight.size();
         }
     }
 
-    /** Test hook: clear all in-flight state without firing cancellation logic. */
+    /**
+     * Test hook: clear all in-flight state without firing cancellation logic.
+     */
     public void resetForTest() {
         synchronized (inFlightLock) {
             for (RewardClaim claim : inFlight.values()) {
@@ -97,12 +106,16 @@ public class RewardClaimManager {
         }
     }
 
-    /** Test hook: substitute the HTTP sender. */
+    /**
+     * Test hook: substitute the HTTP sender.
+     */
     public void setSenderForTest(@Nullable ClaimRequestSender sender) {
         this.sender = sender;
     }
 
-    /** Test hook: substitute the scheduler. */
+    /**
+     * Test hook: substitute the scheduler.
+     */
     public void setSchedulerForTest(@NonNull ScheduledExecutorService scheduler) {
         this.scheduler = scheduler;
     }
@@ -119,22 +132,47 @@ public class RewardClaimManager {
     private RewardClaimManager() {}
 
     /**
-     * Start polling for a claim that the server returned {@code claim_pending} for.
-     * Idempotent: re-entrant calls for the same {@code eventId} while the entry is in flight
-     * are dropped silently.
+     * Start polling for a claim that the server returned {@code claim_pending} for, with
+     * launch-data attribution for the originating click. Convenience for the click-time
+     * path: flattens {@code launchData} once into the eleven-key attribution map and
+     * delegates to {@link #startPoll(String, String, Session, Map)}.
+     *
+     * <p>Idempotent: re-entrant calls for the same {@code eventId} while the entry is in
+     * flight are dropped silently.
      */
     public void startPoll(@NonNull String eventId, @Nullable String teakRewardId,
         @NonNull Session originatingSession, @Nullable Teak.AttributedLaunchData launchData) {
+        startPoll(eventId, teakRewardId, originatingSession, attributionMapFromLaunchData(launchData));
+    }
+
+    /**
+     * Start polling with the eleven-key attribution map directly. Used by the session-start
+     * sweep dispatcher, which sources attribution from the wire {@code session_attribution}
+     * blob rather than a launch-data object.
+     *
+     * <p>Idempotent: re-entrant calls for the same {@code eventId} while the entry is in
+     * flight are dropped silently. This is the dedupe site between click-time and sweep
+     * paths.
+     */
+    public void startPoll(@NonNull String eventId, @Nullable String teakRewardId,
+        @NonNull Session originatingSession, @NonNull Map<String, Object> attribution) {
         synchronized (inFlightLock) {
             if (inFlight.containsKey(eventId)) {
                 Teak.log.i("claim_poll.start.duplicate", logEntry(eventId));
                 return;
             }
 
-            final RewardClaim claim = new RewardClaim(eventId, teakRewardId, originatingSession, launchData);
+            final RewardClaim claim = new RewardClaim(eventId, teakRewardId, originatingSession, attribution);
             inFlight.put(eventId, claim);
             schedulePoll(claim);
         }
+    }
+
+    @NonNull
+    private static Map<String, Object> attributionMapFromLaunchData(
+        @Nullable Teak.AttributedLaunchData launchData) {
+        if (launchData == null) return Collections.emptyMap();
+        return launchData.toMap();
     }
 
     /**
@@ -261,11 +299,9 @@ public class RewardClaimManager {
 
             // Fire the resolved-event observer first, then start the ack POST. Order matters:
             // host games observe the reward grant before the SDK marks it acknowledged.
-            if (claim.launchData != null) {
-                Session.whenUserIdIsReadyPost(
-                    new Teak.RewardClaimResolvedEvent(claim.launchData, claim.eventId, reply));
-                Teak.log.i("claim_resolved.delivered", logEntry(claim.eventId));
-            }
+            Session.whenUserIdIsReadyPost(
+                new Teak.RewardClaimResolvedEvent(claim.attribution, claim.eventId, reply));
+            Teak.log.i("claim_resolved.delivered", logEntry(claim.eventId));
 
             scheduleAck(claim);
             return;
@@ -278,8 +314,8 @@ public class RewardClaimManager {
 
     private void scheduleAck(@NonNull final RewardClaim claim) {
         final long delayMs = claim.ackAttempt == 0
-            ? 0L
-            : computeBackoffMs(claim.ackAttempt - 1, currentInitialMs(), currentCeilingMs());
+                                 ? 0L
+                                 : computeBackoffMs(claim.ackAttempt - 1, currentInitialMs(), currentCeilingMs());
         claim.nextAckFuture = scheduler.schedule(new Runnable() {
             @Override
             public void run() {
@@ -365,6 +401,139 @@ public class RewardClaimManager {
         }
     }
 
+    /**
+     * Fire the session-start sweep against {@code GET /claims}. Reads the unacked-claims
+     * list for the supplied session's user id and dispatches each entry through
+     * {@link #dispatchSweptClaims}. A non-2xx or empty/unparseable body is treated as no
+     * claims to surface this launch — the at-least-once contract on
+     * {@link Teak.RewardClaimResolvedEvent} re-tries on the next session start.
+     */
+    public void startSweep(@NonNull final Session originatingSession) {
+        final ClaimRequestSender s = effectiveSender();
+        if (s == null) {
+            Teak.log.i("claim_sweep.no_sender", new HashMap<String, Object>());
+            return;
+        }
+
+        final String teakAppId = currentAppId();
+        final String clickingUserId = originatingSession.userId() == null ? "" : originatingSession.userId();
+        if (clickingUserId.isEmpty() || teakAppId.isEmpty()) {
+            // No user / no app id → nothing to sweep against.
+            return;
+        }
+
+        Teak.log.i("claim_sweep.request.send", new HashMap<>());
+        s.sendSweep(teakAppId, clickingUserId, new ReplyHandler() {
+            @Override
+            public void onReply(int statusCode, @Nullable String body) {
+                if (statusCode < 200 || statusCode >= 300 || body == null) {
+                    final Map<String, Object> data = new HashMap<>();
+                    data.put("status_code", statusCode);
+                    Teak.log.i("claim_sweep.request.error", data);
+                    return;
+                }
+                JSONArray claims = null;
+                try {
+                    final JSONObject reply = new JSONObject(body);
+                    claims = reply.optJSONArray("claims");
+                } catch (Exception ignored) {
+                }
+                if (claims == null) return;
+                dispatchSweptClaims(claims, originatingSession);
+            }
+        });
+    }
+
+    /**
+     * Per-claim dispatch for a sweep response. Wire-free seam used by both production
+     * ({@link #startSweep}) and tests. Each entry must carry an {@code event_id} and
+     * {@code status}; malformed entries are dropped with the rest of the list dispatched.
+     *
+     * <p>Branching:
+     * <ul>
+     *   <li>Terminal ({@code completed} / {@code failed}): enroll into the in-flight
+     *       dictionary, fire {@link Teak.RewardClaimResolvedEvent}, schedule the ack.</li>
+     *   <li>Pending: enroll into the in-flight dictionary and schedule the next poll. Does
+     *       not fire {@link Teak.RewardClaimPendingEvent} — Pending is point-in-time.</li>
+     * </ul>
+     *
+     * <p>Idempotency is the existing in-flight dictionary's {@code event_id} key — sweep
+     * entries for an id already mid-poll, mid-request, or post-resolve awaiting ack are
+     * no-ops via the dedupe guard in {@link #startPoll}.
+     */
+    public void dispatchSweptClaims(@NonNull JSONArray claims, @NonNull Session originatingSession) {
+        for (int i = 0; i < claims.length(); i++) {
+            final JSONObject entry = claims.optJSONObject(i);
+            if (entry == null) continue;
+
+            final String eventId = entry.optString("event_id", null);
+            if (eventId == null || eventId.isEmpty()) continue;
+
+            final String status = entry.optString("status", null);
+            final boolean isTerminal =
+                STATUS_COMPLETED.equals(status) || STATUS_FAILED.equals(status);
+            final boolean isPending = STATUS_PENDING.equals(status);
+            if (!isTerminal && !isPending) continue;
+
+            final Map<String, Object> attribution = unpackSessionAttribution(entry.opt("session_attribution"));
+            final String teakRewardId = teakRewardIdFromAttribution(attribution);
+
+            synchronized (inFlightLock) {
+                if (inFlight.containsKey(eventId)) {
+                    Teak.log.i("claim_sweep.dedupe", logEntry(eventId));
+                    continue;
+                }
+
+                final RewardClaim claim = new RewardClaim(
+                    eventId, teakRewardId, originatingSession, attribution);
+                inFlight.put(eventId, claim);
+
+                if (isTerminal) {
+                    claim.resolvedReply = entry;
+                    Teak.log.i("claim_sweep.resolved", logEntry(eventId));
+                    Session.whenUserIdIsReadyPost(
+                        new Teak.RewardClaimResolvedEvent(claim.attribution, eventId, entry));
+                    scheduleAck(claim);
+                } else {
+                    Teak.log.i("claim_sweep.pending", logEntry(eventId));
+                    schedulePoll(claim);
+                }
+            }
+        }
+    }
+
+    /**
+     * Decode the wire {@code session_attribution} field. The blob is opaque text on the
+     * server (per the wire-format spec); the SDK accepts either an inline JSON object or
+     * a JSON-encoded string for forward-compat with either taro encoding choice. Anything
+     * else returns the empty map — attribution is best-effort context, not a gate on
+     * dispatch.
+     */
+    @NonNull
+    private static Map<String, Object> unpackSessionAttribution(@Nullable Object raw) {
+        if (raw == null) return Collections.emptyMap();
+        if (raw instanceof JSONObject) {
+            return ((JSONObject) raw).toMap();
+        }
+        if (raw instanceof String) {
+            final String s = (String) raw;
+            if (s.isEmpty()) return Collections.emptyMap();
+            try {
+                return new JSONObject(s).toMap();
+            } catch (Exception ignored) {
+                return Collections.emptyMap();
+            }
+        }
+        return Collections.emptyMap();
+    }
+
+    @Nullable
+    private static String teakRewardIdFromAttribution(@NonNull Map<String, Object> attribution) {
+        final Object v = attribution.get("teakRewardId");
+        if (v instanceof String && !((String) v).isEmpty()) return (String) v;
+        return null;
+    }
+
     @NonNull
     private static Map<String, Object> logEntry(@NonNull String eventId) {
         final Map<String, Object> data = new HashMap<>();
@@ -432,7 +601,9 @@ public class RewardClaimManager {
         return Math.min(scaled, ceilingMs);
     }
 
-    /** Wired from {@link TeakCore} alongside the other static registrations. */
+    /**
+     * Wired from {@link TeakCore} alongside the other static registrations.
+     */
     public static void registerStaticEventListeners() {
         TeakEvent.addEventListener(event -> {
             if (!SessionStateEvent.Type.equals(event.eventType)) return;

--- a/src/main/java/io/teak/sdk/core/RewardClaimManager.java
+++ b/src/main/java/io/teak/sdk/core/RewardClaimManager.java
@@ -462,6 +462,12 @@ public class RewardClaimManager {
      * no-ops via the dedupe guard in {@link #startPoll}.
      */
     public void dispatchSweptClaims(@NonNull JSONArray claims, @NonNull Session originatingSession) {
+        // Collect terminal events to fire and post them outside the synchronized block.
+        // whenUserIdIsReadyPost recurses into Session.currentSessionLock + Session.stateLock;
+        // posting under inFlightLock is a future-deadlock seed (no current cycle, but the
+        // click-time onPollReply path posts outside the lock for the same reason).
+        final List<Teak.RewardClaimResolvedEvent> resolvedToPost = new ArrayList<>();
+
         for (int i = 0; i < claims.length(); i++) {
             final JSONObject entry = claims.optJSONObject(i);
             if (entry == null) continue;
@@ -491,7 +497,7 @@ public class RewardClaimManager {
                 if (isTerminal) {
                     claim.resolvedReply = entry;
                     Teak.log.i("claim_sweep.resolved", logEntry(eventId));
-                    Session.whenUserIdIsReadyPost(
+                    resolvedToPost.add(
                         new Teak.RewardClaimResolvedEvent(claim.attribution, eventId, entry));
                     scheduleAck(claim);
                 } else {
@@ -499,6 +505,10 @@ public class RewardClaimManager {
                     schedulePoll(claim);
                 }
             }
+        }
+
+        for (Teak.RewardClaimResolvedEvent event : resolvedToPost) {
+            Session.whenUserIdIsReadyPost(event);
         }
     }
 

--- a/src/main/java/io/teak/sdk/core/Session.java
+++ b/src/main/java/io/teak/sdk/core/Session.java
@@ -66,7 +66,7 @@ public class Session {
         Expiring("Expiring"),
         Expired("Expired");
 
-        //public static final Integer length = 1 + Expired.ordinal();
+        // public static final Integer length = 1 + Expired.ordinal();
 
         private static final State[][] allowedTransitions = {
             {},
@@ -267,6 +267,21 @@ public class Session {
                     // Process deep link and/or rewards and send out events
                     processAttributionAndDispatchEvents();
 
+                    // Resurface unacked server-jwt claims for at-least-once delivery on
+                    // RewardClaimResolvedEvent. Skipped on the Expiring → UserIdentified
+                    // flicker (rapid background-foreground within SAME_SESSION_TIME_DELTA)
+                    // — the same Session instance keeps any in-flight click-time poll
+                    // alive across that transition, and a re-sweep would risk a double-
+                    // fire for any claim whose ack hasn't yet committed server-side. The
+                    // post-120s resume path goes through hasExpired → new Session →
+                    // IdentifyingUser → UserIdentified, so the gate doesn't filter the
+                    // design's primary use case (player kicks off a server-jwt click,
+                    // backgrounds long enough to cycle Session, foregrounds → sweep
+                    // retrieves the customer-server resolution).
+                    if (this.state != State.Expiring) {
+                        RewardClaimManager.get().startSweep(this);
+                    }
+
                     // If we are currently expiring, reset the future that will report duration
                     // and send the server a "hey nevermind, I'm back" message
                     if (this.state == State.Expiring) {
@@ -294,7 +309,7 @@ public class Session {
                         TeakCore.operationQueue.execute(this.userProfile);
                     }
 
-                    if(this.serverSessionId != null) {
+                    if (this.serverSessionId != null) {
                         this.sessionVectorClock++;
                         // This is a message to the server that, in effect, says "If you don't hear
                         // from me again, consider this session over"
@@ -334,7 +349,7 @@ public class Session {
             TeakEvent.postEvent(new SessionStateEvent(this, this.state, this.previousState));
 
             TeakConfiguration teakConfiguration = TeakConfiguration.get();
-            //noinspection all - Seriously, that is not a simplification
+            // noinspection all - Seriously, that is not a simplification
             if (this.state == State.Created && teakConfiguration != null && teakConfiguration.remoteConfiguration != null) {
                 return setState(State.Configured);
             } else {
@@ -355,7 +370,7 @@ public class Session {
         }
 
         // TODO: Revist this when we have time, if it is important
-        //noinspection deprecation - Alex said "ehhhhhhh" to changing the heartbeat param to a map
+        // noinspection deprecation - Alex said "ehhhhhhh" to changing the heartbeat param to a map
         @SuppressWarnings("deprecation")
         final String teakSdkVersion = Teak.SDKVersion;
 
@@ -722,7 +737,7 @@ public class Session {
                     }
                     break;
                 case LifecycleEvent.Resumed:
-                    LifecycleEvent lEvent = (LifecycleEvent)event;
+                    LifecycleEvent lEvent = (LifecycleEvent) event;
                     onActivityResumed(lEvent.intent, lEvent.context);
                     break;
             }
@@ -939,7 +954,7 @@ public class Session {
     private void forceExpire() {
         stateLock.lock();
         try {
-            if(state != State.Expired) {
+            if (state != State.Expired) {
                 setState(State.Expiring);
                 setState(State.Expired);
             }
@@ -988,7 +1003,7 @@ public class Session {
             } else if (launchDataSource != LaunchDataSource.Unattributed) {
                 Session oldSession = currentSession;
                 currentSession = new Session(oldSession, launchDataSource);
-                if(oldSession != null) {
+                if (oldSession != null) {
                     oldSession.forceExpire();
                 }
             } else {

--- a/test_app/app/src/test/java/io/teak/app/test/RewardClaimManagerTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/RewardClaimManagerTest.java
@@ -140,7 +140,7 @@ public class RewardClaimManagerTest extends TeakUnitTest {
         final Session session = makeSyntheticSession();
         setCurrentSession(session);
         try {
-            RewardClaimManager.get().startPoll("evt-1", "reward-1", session, null);
+            RewardClaimManager.get().startPoll("evt-1", "reward-1", session, (Teak.AttributedLaunchData) null);
             assertEquals(1, RewardClaimManager.get().inFlightCount());
 
             // First scheduled poll fires.
@@ -241,7 +241,7 @@ public class RewardClaimManagerTest extends TeakUnitTest {
         final Session originatingSession = makeSyntheticSessionWithUser("player-original");
         setCurrentSession(originatingSession);
         try {
-            RewardClaimManager.get().startPoll("evt-1", "reward-1", originatingSession, null);
+            RewardClaimManager.get().startPoll("evt-1", "reward-1", originatingSession, (Teak.AttributedLaunchData) null);
             scheduler.runNext();
             sender.completeLastPoll(200, "{\"status\":\"completed\",\"reward\":{}}");
             // onPollReply ran synchronously: resolved event posted, ack scheduled.
@@ -434,7 +434,6 @@ public class RewardClaimManagerTest extends TeakUnitTest {
         f.set(null, session);
     }
 
-
     /**
      * Records every poll/ack call so the test can inspect parameters and complete them on
      * its own schedule.
@@ -467,6 +466,13 @@ public class RewardClaimManagerTest extends TeakUnitTest {
         public void sendAck(String eventId, String teakAppId, String clickingUserId,
             RewardClaimManager.ReplyHandler handler) {
             acks.add(new Call(eventId, teakAppId, clickingUserId, handler));
+        }
+
+        @Override
+        public void sendSweep(String teakAppId, String clickingUserId,
+            RewardClaimManager.ReplyHandler handler) {
+            // Sweep is unused in this test class — the sweep tests live in
+            // SessionStartSweepTests. No-op satisfies the interface.
         }
 
         void completeLastPoll(int statusCode, String body) {

--- a/test_app/app/src/test/java/io/teak/app/test/RewardClickReplyDispatchTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/RewardClickReplyDispatchTest.java
@@ -41,7 +41,6 @@ import static org.junit.Assert.assertTrue;
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class RewardClickReplyDispatchTest extends TeakUnitTest {
 
-
     private static final Field userIdReadyEventBusQueueField;
     private static final Method dispatchClickReply;
     private static final Constructor<TeakNotification.Reward> rewardCtor;
@@ -212,6 +211,11 @@ public class RewardClickReplyDispatchTest extends TeakUnitTest {
         final android.net.Uri uri = org.mockito.Mockito.mock(android.net.Uri.class);
         org.mockito.Mockito.when(uri.isOpaque()).thenReturn(false);
         org.mockito.Mockito.when(uri.isHierarchical()).thenReturn(true);
+        // Click-time path now flattens launchData into the eleven-key attribution map at
+        // startPoll, which routes through DeepLink.willProcessUri → URI.create(toString()).
+        // Default Mockito toString ("Mock for Uri, hashCode: ...") fails URI.create; stub
+        // a real URI string.
+        org.mockito.Mockito.when(uri.toString()).thenReturn("teak123://launch");
         org.mockito.Mockito.when(uri.getQueryParameter("teak_reward_id")).thenReturn(teakRewardId);
         org.mockito.Mockito.when(uri.getQueryParameter("teak_channel_name")).thenReturn("android_push");
         org.mockito.Mockito.when(uri.getQueryParameter("teak_creative_name")).thenReturn("fixture-creative");

--- a/test_app/app/src/test/java/io/teak/app/test/SessionStartSweepTests.java
+++ b/test_app/app/src/test/java/io/teak/app/test/SessionStartSweepTests.java
@@ -1,0 +1,436 @@
+package io.teak.app.test;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.teak.sdk.Teak;
+import io.teak.sdk.core.RewardClaimManager;
+import io.teak.sdk.core.Session;
+import io.teak.sdk.json.JSONArray;
+import io.teak.sdk.json.JSONObject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Spec for the session-start /claims sweep dispatcher. Pins the contract independent of the
+ * wire layer: {@code dispatchSweptClaims(JSONArray, Session)} is a wire-free seam exercising
+ * per-claim enrollment, dedupe vs the click-time path, terminal/pending branching, and
+ * tolerance to malformed entries and string-encoded {@code session_attribution} blobs.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class SessionStartSweepTests extends TeakUnitTest {
+
+    private RecordingSender sender;
+    private DeterministicScheduler scheduler;
+
+    @Before
+    public void resetManager() throws Exception {
+        RewardClaimManager.get().resetForTest();
+        sender = new RecordingSender();
+        scheduler = new DeterministicScheduler();
+        RewardClaimManager.get().setSenderForTest(sender);
+        RewardClaimManager.get().setSchedulerForTest(scheduler);
+        clearEventBusQueue();
+    }
+
+    @After
+    public void clearManager() throws Exception {
+        RewardClaimManager.get().resetForTest();
+        RewardClaimManager.get().setSenderForTest(null);
+        clearEventBusQueue();
+        setCurrentSession(null);
+    }
+
+    // --- Resolved event payload from sweep (attribution-map merge) ---
+
+    /// The dict-taking RewardClaimResolvedEvent constructor merges the eleven-key attribution
+    /// map and the wire reply at fire time. Reply wins on key collision — same merge order
+    /// as the launchData-flattened click-time path. The two reward-id flavors (teakRewardId
+    /// attribution vs. teak_reward_id authoritative) are tracked distinctly: teakRewardId
+    /// surfaces on the userInfo, teak_reward_id is in the strip set.
+    @Test
+    public void resolvedEvent_fromAttributionMap_mergesAttributionAndReply() throws Exception {
+        final Map<String, Object> attribution = new HashMap<>();
+        attribution.put("launch_link", "teaktest-app://chest");
+        attribution.put("teakNotifId", "2048153148060669486");
+        attribution.put("teakScheduleId", "2046986133304291328");
+        attribution.put("teakScheduleName", "daily_promo_2026q2");
+        attribution.put("teakCreativeId", "2046986561123301779");
+        attribution.put("teakCreativeName", "summer_sale_v3");
+        attribution.put("teakRewardId", "2048153148060669138");
+        attribution.put("teakChannelName", "android_push");
+        attribution.put("teakDeepLink", null);
+        attribution.put("teakOptOutCategory", "teak");
+        attribution.put("teakSystemActivityId", null);
+
+        final JSONObject reply = new JSONObject();
+        reply.put("event_id", "evt-resurfaced-1");
+        reply.put("status", "completed");
+        reply.put("reward", new JSONObject(new HashMap<String, Object>() {{
+            put("gems", 25);
+        } }));
+        reply.put("customer_status_code", 200);
+        reply.put("teak_reward_id", "2048153148060669999");
+
+        final Teak.RewardClaimResolvedEvent event =
+            new Teak.RewardClaimResolvedEvent(attribution, "evt-resurfaced-1", reply);
+
+        final JSONObject payload = event.toJSON();
+        assertEquals("evt-resurfaced-1", payload.getString("event_id"));
+        assertEquals("completed", payload.getString("status"));
+        assertEquals(200, payload.getInt("customer_status_code"));
+
+        assertEquals("2048153148060669486", payload.getString("teakNotifId"));
+        assertEquals("2046986133304291328", payload.getString("teakScheduleId"));
+        assertEquals("summer_sale_v3", payload.getString("teakCreativeName"));
+        assertEquals("android_push", payload.getString("teakChannelName"));
+        assertEquals("2048153148060669138", payload.getString("teakRewardId"));
+
+        assertFalse("teak_reward_id (server-authoritative grant id) must NOT appear on the resolved-event userInfo",
+            payload.has("teak_reward_id"));
+        assertFalse("raw session_attribution blob must NOT appear on the resolved-event userInfo",
+            payload.has("session_attribution"));
+
+        assertTrue("teakDeepLink must arrive as JSON null when unset, not absent",
+            payload.isNull("teakDeepLink"));
+        assertTrue("teakSystemActivityId must arrive as JSON null on Android (always-null platform)",
+            payload.isNull("teakSystemActivityId"));
+    }
+
+    // --- Sweep dispatch: pending vs terminal branching ---
+
+    /// Pending sweep entries enroll into the in-flight dictionary so the existing poll
+    /// scheduler picks them up. The cross-SDK contract: pending claims surfaced by the sweep
+    /// continue with the same poll loop the click-time path uses, no parallel implementation.
+    @Test
+    public void sweep_registersPendingClaimInInflightDictionary() throws Exception {
+        final Session session = makeSyntheticSession();
+        setCurrentSession(session);
+
+        final JSONArray claims = new JSONArray();
+        claims.put(buildClaim("evt-sweep-pending-1", "pending",
+            buildAttribution("2048153148060669486", "2048153148060669138", "android_push"),
+            null));
+
+        RewardClaimManager.get().dispatchSweptClaims(claims, session);
+
+        assertEquals(1, RewardClaimManager.get().inFlightCount());
+        assertTrue(RewardClaimManager.get().inFlightEventIdsForTest().contains("evt-sweep-pending-1"));
+    }
+
+    /// Terminal sweep entries also enroll into the in-flight dictionary so the existing
+    /// retriable /claim_ack machinery (with its bounded retry budget and originating-session
+    /// pin) handles ack for the resurfaced claim.
+    @Test
+    public void sweep_registersTerminalClaimInInflightDictionary() throws Exception {
+        final Session session = makeSyntheticSession();
+        setCurrentSession(session);
+
+        final JSONObject reward = new JSONObject();
+        reward.put("gems", 25);
+
+        final JSONArray claims = new JSONArray();
+        claims.put(buildClaim("evt-sweep-terminal-1", "completed",
+            buildAttribution("2048153148060669486", null, null), reward));
+
+        RewardClaimManager.get().dispatchSweptClaims(claims, session);
+
+        assertEquals(1, RewardClaimManager.get().inFlightCount());
+        assertTrue(RewardClaimManager.get().inFlightEventIdsForTest().contains("evt-sweep-terminal-1"));
+    }
+
+    /// Terminal sweep entries fire {@link Teak.RewardClaimResolvedEvent} via the
+    /// whenUserIdIsReadyPost queue — same surface the click-time poll uses on terminal
+    /// reply. The host-game-facing contract: a single canonical resolved-event shape
+    /// regardless of source (poll vs sweep).
+    @Test
+    public void sweep_terminalEntry_firesRewardClaimResolvedEvent() throws Exception {
+        final Session session = makeSyntheticSession();
+        setCurrentSession(session);
+
+        final JSONObject reward = new JSONObject();
+        reward.put("gems", 25);
+
+        final JSONArray claims = new JSONArray();
+        claims.put(buildClaim("evt-sweep-fire-1", "completed",
+            buildAttribution("2048153148060669486", "2048153148060669138", "android_push"),
+            reward));
+
+        RewardClaimManager.get().dispatchSweptClaims(claims, session);
+
+        final Teak.RewardClaimResolvedEvent resolved = findResolvedEvent("evt-sweep-fire-1");
+        assertNotNull("terminal sweep entry must enqueue RewardClaimResolvedEvent", resolved);
+
+        final JSONObject payload = resolved.toJSON();
+        assertEquals("evt-sweep-fire-1", payload.getString("event_id"));
+        assertEquals("completed", payload.getString("status"));
+        assertEquals("2048153148060669486", payload.getString("teakNotifId"));
+        assertEquals("2048153148060669138", payload.getString("teakRewardId"));
+        assertEquals("android_push", payload.getString("teakChannelName"));
+    }
+
+    // --- Sweep dispatch: idempotency vs click-time path ---
+
+    /// A claim that's already in flight from a click-time start MUST NOT be re-entered by
+    /// the sweep. The dedupe guard is the existing in-flight dictionary keyed on event_id.
+    @Test
+    public void sweep_skipsClaimAlreadyInFlightFromClickTime() throws Exception {
+        final Session session = makeSyntheticSession();
+        setCurrentSession(session);
+
+        // Click-time start.
+        RewardClaimManager.get().startPoll("evt-clicktime-already-1", "reward-1", session,
+            (Teak.AttributedLaunchData) null);
+        assertEquals(1, RewardClaimManager.get().inFlightCount());
+
+        // Sweep with the same event_id — terminal. Must be a no-op for enrollment.
+        final JSONArray claims = new JSONArray();
+        claims.put(buildClaim("evt-clicktime-already-1", "completed",
+            buildAttribution("2048153148060669486", null, null), new JSONObject()));
+
+        RewardClaimManager.get().dispatchSweptClaims(claims, session);
+
+        assertEquals("sweep dedupe must keep the in-flight dictionary at one entry",
+            1, RewardClaimManager.get().inFlightCount());
+    }
+
+    // --- Sweep dispatch: pending does NOT re-fire ClaimPending ---
+
+    /// Per cross-SDK conventions: ClaimPending is a point-in-time event, not a history-replay
+    /// event. The sweep enrolls pending entries into the poll loop without re-firing
+    /// {@link Teak.RewardClaimPendingEvent}. Host games that listened on click-time already
+    /// saw the optimistic surface; resurfaced pendings just continue polling silently until
+    /// terminal.
+    @Test
+    public void sweep_pendingEntry_doesNotFireRewardClaimPendingEvent() throws Exception {
+        final Session session = makeSyntheticSession();
+        setCurrentSession(session);
+
+        final JSONArray claims = new JSONArray();
+        claims.put(buildClaim("evt-sweep-pending-silent-1", "pending",
+            buildAttribution("2048153148060669486", null, null), null));
+
+        RewardClaimManager.get().dispatchSweptClaims(claims, session);
+
+        assertNull("sweep must never fire RewardClaimPendingEvent — Pending is point-in-time only",
+            findEventOfType(Teak.RewardClaimPendingEvent.class));
+    }
+
+    // --- Sweep dispatch: input tolerance ---
+
+    /// An empty claims list is a valid response shape (the user has no unacked claims) —
+    /// sweep dispatcher must handle it without enrolling any entries or crashing.
+    @Test
+    public void sweep_emptyClaimsList_doesNotCrashAndDoesNotEnroll() throws Exception {
+        final Session session = makeSyntheticSession();
+        setCurrentSession(session);
+
+        RewardClaimManager.get().dispatchSweptClaims(new JSONArray(), session);
+
+        assertEquals(0, RewardClaimManager.get().inFlightCount());
+    }
+
+    /// A malformed individual claim entry (missing event_id) is dropped without taking the
+    /// rest of the list down. The dispatcher iterates defensively so a single server-side
+    /// anomaly doesn't strand the user's other unacked claims.
+    @Test
+    public void sweep_skipsMalformedEntriesAndDispatchesRest() throws Exception {
+        final Session session = makeSyntheticSession();
+        setCurrentSession(session);
+
+        // Missing event_id, empty event_id, and a valid one.
+        final JSONArray claims = new JSONArray();
+        {
+            final JSONObject missingEventId = new JSONObject();
+            missingEventId.put("status", "completed");
+            claims.put(missingEventId);
+        }
+        claims.put(buildClaim("evt-good-1", "pending", buildAttribution("notif-1", null, null), null));
+        {
+            final JSONObject emptyEventId = new JSONObject();
+            emptyEventId.put("event_id", "");
+            emptyEventId.put("status", "completed");
+            claims.put(emptyEventId);
+        }
+
+        RewardClaimManager.get().dispatchSweptClaims(claims, session);
+
+        assertEquals("only the well-formed claim should be enrolled",
+            1, RewardClaimManager.get().inFlightCount());
+        assertTrue(RewardClaimManager.get().inFlightEventIdsForTest().contains("evt-good-1"));
+    }
+
+    // --- Sweep dispatch: session_attribution unpack tolerance ---
+
+    /// session_attribution may arrive as a JSON-encoded string (mirrors the click-POST mint
+    /// shape) or as an inline object. The sweep dispatcher tolerates both forms so the SDK
+    /// is robust to either taro-side encoding choice.
+    @Test
+    public void sweep_unpacksSessionAttributionFromJsonString() throws Exception {
+        final Session session = makeSyntheticSession();
+        setCurrentSession(session);
+
+        // Build the attribution as a JSON-encoded string and embed it as the
+        // session_attribution field of the claim entry.
+        final JSONObject attributionInline = new JSONObject();
+        attributionInline.put("teakNotifId", "2048153148060669486");
+        attributionInline.put("teakRewardId", "2048153148060669138");
+        attributionInline.put("teakChannelName", "android_push");
+        final String attributionString = attributionInline.toString();
+
+        final JSONObject claim = new JSONObject();
+        claim.put("event_id", "evt-sweep-string-attr-1");
+        claim.put("status", "completed");
+        claim.put("session_attribution", attributionString);
+        claim.put("reward", new JSONObject());
+
+        final JSONArray claims = new JSONArray();
+        claims.put(claim);
+
+        RewardClaimManager.get().dispatchSweptClaims(claims, session);
+
+        // Enrollment proves the string form was accepted.
+        assertTrue("sweep must accept session_attribution as a JSON-encoded string",
+            RewardClaimManager.get().inFlightEventIdsForTest().contains("evt-sweep-string-attr-1"));
+
+        // The resolved event must surface attribution keys derived from the string-form
+        // unpack — proves the JSON-decode happened, not just a tolerated-but-ignored input.
+        final Teak.RewardClaimResolvedEvent resolved = findResolvedEvent("evt-sweep-string-attr-1");
+        assertNotNull(resolved);
+        final JSONObject payload = resolved.toJSON();
+        assertEquals("2048153148060669486", payload.getString("teakNotifId"));
+        assertEquals("2048153148060669138", payload.getString("teakRewardId"));
+        assertEquals("android_push", payload.getString("teakChannelName"));
+    }
+
+    // --- helpers ---
+
+    private static JSONObject buildAttribution(String teakNotifId, String teakRewardId,
+        String teakChannelName) {
+        final JSONObject attr = new JSONObject();
+        // Eleven-key always-present contract: every key carries either a string value or
+        // JSON null. Tests pass null for unset keys; JSONObject stores them explicitly so
+        // the read-side dict-or-string unpack sees the same shape.
+        attr.put("launch_link", JSONObject.NULL);
+        attr.put("teakScheduleName", JSONObject.NULL);
+        attr.put("teakScheduleId", JSONObject.NULL);
+        attr.put("teakCreativeName", JSONObject.NULL);
+        attr.put("teakCreativeId", JSONObject.NULL);
+        attr.put("teakRewardId", teakRewardId == null ? JSONObject.NULL : teakRewardId);
+        attr.put("teakChannelName", teakChannelName == null ? JSONObject.NULL : teakChannelName);
+        attr.put("teakDeepLink", JSONObject.NULL);
+        attr.put("teakOptOutCategory", JSONObject.NULL);
+        attr.put("teakNotifId", teakNotifId == null ? JSONObject.NULL : teakNotifId);
+        attr.put("teakSystemActivityId", JSONObject.NULL);
+        return attr;
+    }
+
+    private static JSONObject buildClaim(String eventId, String status, JSONObject attribution,
+        JSONObject reward) {
+        final JSONObject claim = new JSONObject();
+        claim.put("event_id", eventId);
+        claim.put("status", status);
+        claim.put("session_attribution", attribution);
+        if (reward != null) {
+            claim.put("reward", reward);
+        }
+        return claim;
+    }
+
+    private static Session makeSyntheticSession() throws Exception {
+        return makeSyntheticSessionWithUser("synthetic-user");
+    }
+
+    private static Session makeSyntheticSessionWithUser(String userId) throws Exception {
+        final Constructor<Session> ctor = Session.class.getDeclaredConstructor(String.class);
+        ctor.setAccessible(true);
+        final Session session = ctor.newInstance("synthetic:" + userId);
+        try {
+            final Field userField = Session.class.getDeclaredField("userId");
+            userField.setAccessible(true);
+            userField.set(session, userId);
+        } catch (Exception ignored) {
+        }
+        return session;
+    }
+
+    private static void setCurrentSession(Session session) throws Exception {
+        final Field f = Session.class.getDeclaredField("currentSession");
+        f.setAccessible(true);
+        f.set(null, session);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void clearEventBusQueue() throws Exception {
+        final Field f = Session.class.getDeclaredField("userIdReadyEventBusQueue");
+        f.setAccessible(true);
+        ((List<Object>) f.get(null)).clear();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Teak.RewardClaimResolvedEvent findResolvedEvent(String eventId) throws Exception {
+        final Field f = Session.class.getDeclaredField("userIdReadyEventBusQueue");
+        f.setAccessible(true);
+        for (Object o : (List<Object>) f.get(null)) {
+            if (o instanceof Teak.RewardClaimResolvedEvent && eventId.equals(((Teak.RewardClaimResolvedEvent) o).eventId)) {
+                return (Teak.RewardClaimResolvedEvent) o;
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T findEventOfType(Class<T> klass) throws Exception {
+        final Field f = Session.class.getDeclaredField("userIdReadyEventBusQueue");
+        f.setAccessible(true);
+        for (Object o : (List<Object>) f.get(null)) {
+            if (klass.isInstance(o)) {
+                return (T) o;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Records sweep / poll / ack calls so terminal-firing tests don't blow up on a missing
+     * sender. The dispatcher schedules an ack for terminal entries; we let it queue without
+     * driving the scheduler.
+     */
+    private static class RecordingSender implements RewardClaimManager.ClaimRequestSender {
+        final List<Object[]> sweeps = new ArrayList<>();
+        final List<Object[]> polls = new ArrayList<>();
+        final List<Object[]> acks = new ArrayList<>();
+
+        @Override
+        public void sendPoll(String eventId, String teakAppId, String clickingUserId,
+            RewardClaimManager.ReplyHandler handler) {
+            polls.add(new Object[] {eventId, teakAppId, clickingUserId, handler});
+        }
+
+        @Override
+        public void sendAck(String eventId, String teakAppId, String clickingUserId,
+            RewardClaimManager.ReplyHandler handler) {
+            acks.add(new Object[] {eventId, teakAppId, clickingUserId, handler});
+        }
+
+        @Override
+        public void sendSweep(String teakAppId, String clickingUserId,
+            RewardClaimManager.ReplyHandler handler) {
+            sweeps.add(new Object[] {teakAppId, clickingUserId, handler});
+        }
+    }
+}

--- a/test_app/app/src/test/java/io/teak/app/test/SessionStartSweepTests.java
+++ b/test_app/app/src/test/java/io/teak/app/test/SessionStartSweepTests.java
@@ -85,6 +85,8 @@ public class SessionStartSweepTests extends TeakUnitTest {
         } }));
         reply.put("customer_status_code", 200);
         reply.put("teak_reward_id", "2048153148060669999");
+        reply.put("created_at", "2026-04-29T20:15:00Z");
+        reply.put("completed_at", "2026-04-29T20:15:04Z");
 
         final Teak.RewardClaimResolvedEvent event =
             new Teak.RewardClaimResolvedEvent(attribution, "evt-resurfaced-1", reply);
@@ -104,6 +106,15 @@ public class SessionStartSweepTests extends TeakUnitTest {
             payload.has("teak_reward_id"));
         assertFalse("raw session_attribution blob must NOT appear on the resolved-event userInfo",
             payload.has("session_attribution"));
+
+        // CEO ruling on cross-SDK strip set (post-iOS-C-724 / post-JS-C-725): created_at
+        // and completed_at are KEPT — they're documented timing fields, not server
+        // bookkeeping. wire_format.md is canonical; iOS TeakClaimPoll.m and JS teak.coffee
+        // both strip only {session_attribution, teak_reward_id}.
+        assertEquals("created_at must pass through to the resolved-event userInfo",
+            "2026-04-29T20:15:00Z", payload.getString("created_at"));
+        assertEquals("completed_at must pass through to the resolved-event userInfo",
+            "2026-04-29T20:15:04Z", payload.getString("completed_at"));
 
         assertTrue("teakDeepLink must arrive as JSON null when unset, not absent",
             payload.isNull("teakDeepLink"));
@@ -315,6 +326,109 @@ public class SessionStartSweepTests extends TeakUnitTest {
         assertEquals("2048153148060669486", payload.getString("teakNotifId"));
         assertEquals("2048153148060669138", payload.getString("teakRewardId"));
         assertEquals("android_push", payload.getString("teakChannelName"));
+    }
+
+    /// A non-JSON string in {@code session_attribution} is treated as no-attribution rather
+    /// than failing the whole entry — the dispatcher's defensive catch keeps a single
+    /// server-side anomaly from stranding the claim. The claim still enrolls and the
+    /// resolved event still fires, just without the eleven attribution keys populated from
+    /// the (un-decodable) blob.
+    @Test
+    public void sweep_malformedSessionAttributionString_isToleratedAsEmptyAttribution() throws Exception {
+        final Session session = makeSyntheticSession();
+        setCurrentSession(session);
+
+        final JSONObject claim = new JSONObject();
+        claim.put("event_id", "evt-sweep-bad-string-1");
+        claim.put("status", "completed");
+        claim.put("session_attribution", "not even close to json {");
+        claim.put("reward", new JSONObject());
+
+        final JSONArray claims = new JSONArray();
+        claims.put(claim);
+
+        RewardClaimManager.get().dispatchSweptClaims(claims, session);
+
+        // The claim still enrolls; the parse failure is dead-letter, not poison-pill.
+        assertTrue(RewardClaimManager.get().inFlightEventIdsForTest().contains("evt-sweep-bad-string-1"));
+
+        // Resolved event still fires; attribution is empty, so the eleven keys flow through
+        // as JSON null on the always-present contract. Reply keys still present.
+        final Teak.RewardClaimResolvedEvent resolved = findResolvedEvent("evt-sweep-bad-string-1");
+        assertNotNull(resolved);
+        final JSONObject payload = resolved.toJSON();
+        assertEquals("evt-sweep-bad-string-1", payload.getString("event_id"));
+        assertEquals("completed", payload.getString("status"));
+    }
+
+    // --- startSweep HTTP-boundary error branches ---
+
+    /// {@code startSweep} short-circuits when the originating session has no user id —
+    /// the {@code GET /claims} request is keyed on {@code clicking_user_id}, so there's
+    /// nothing to send.
+    @Test
+    public void startSweep_skipsWhenSessionHasNoUserId() throws Exception {
+        final Constructor<Session> ctor = Session.class.getDeclaredConstructor(String.class);
+        ctor.setAccessible(true);
+        // No userId field-stamp: userId() returns null on this session.
+        final Session sessionNoUser = ctor.newInstance("synthetic:no-user");
+
+        RewardClaimManager.get().startSweep(sessionNoUser);
+
+        assertEquals("startSweep must not invoke the sender when there is no user id",
+            0, sender.sweeps.size());
+    }
+
+    /// A non-2xx response from {@code GET /claims} is treated as no claims to surface this
+    /// launch — the at-least-once contract on RewardClaimResolvedEvent re-tries on the
+    /// next session start. Nothing should enroll into the in-flight dictionary.
+    @Test
+    public void startSweep_non2xxResponse_doesNotEnroll() throws Exception {
+        final Session session = makeSyntheticSession();
+        setCurrentSession(session);
+
+        RewardClaimManager.get().startSweep(session);
+        assertEquals("startSweep must invoke the sender once", 1, sender.sweeps.size());
+
+        final RewardClaimManager.ReplyHandler handler = (RewardClaimManager.ReplyHandler) sender.sweeps.get(0)[2];
+        handler.onReply(503, "{\"claims\":[{\"event_id\":\"evt-must-not-enroll\",\"status\":\"completed\"}]}");
+
+        assertEquals("non-2xx must not enroll any claims",
+            0, RewardClaimManager.get().inFlightCount());
+    }
+
+    /// A null response body is treated as no claims to surface — same at-least-once
+    /// fallback to next session start.
+    @Test
+    public void startSweep_nullBody_doesNotEnroll() throws Exception {
+        final Session session = makeSyntheticSession();
+        setCurrentSession(session);
+
+        RewardClaimManager.get().startSweep(session);
+        assertEquals(1, sender.sweeps.size());
+
+        final RewardClaimManager.ReplyHandler handler = (RewardClaimManager.ReplyHandler) sender.sweeps.get(0)[2];
+        handler.onReply(200, null);
+
+        assertEquals(0, RewardClaimManager.get().inFlightCount());
+    }
+
+    /// An unparseable body (not JSON, or no {@code claims} key) is treated as no claims
+    /// to surface — defensive against server-side response-shape drift.
+    @Test
+    public void startSweep_unparseableOrMissingClaimsKey_doesNotEnroll() throws Exception {
+        final Session session = makeSyntheticSession();
+        setCurrentSession(session);
+
+        // Unparseable body.
+        RewardClaimManager.get().startSweep(session);
+        ((RewardClaimManager.ReplyHandler) sender.sweeps.get(0)[2]).onReply(200, "not json");
+        assertEquals(0, RewardClaimManager.get().inFlightCount());
+
+        // Valid JSON but no claims key.
+        RewardClaimManager.get().startSweep(session);
+        ((RewardClaimManager.ReplyHandler) sender.sweeps.get(1)[2]).onReply(200, "{\"other_field\":\"value\"}");
+        assertEquals(0, RewardClaimManager.get().inFlightCount());
     }
 
     // --- helpers ---


### PR DESCRIPTION
Closes https://linear.app/teakio/issue/C-702/android-sdk-session-start-claims-sweep

## Summary

After user-identify, the Android SDK pulls `GET /claims?teak_app_id=…&clicking_user_id=…` and dispatches each unacked claim through the same in-flight tracker the click-time path (PR #145) already uses. Terminal entries fire `RewardClaimResolvedEvent` and run the existing retriable ack ceremony; pending entries enroll into the click-time poll loop without re-firing `RewardClaimPendingEvent` (point-in-time event, not history-replay). Idempotency is the in-flight dictionary's `event_id` key — sweep entries for ids already mid-poll, mid-request, or post-resolve awaiting ack are no-ops via the dedupe guard already in `RewardClaimManager.startPoll`.

Parallel to iOS C-699 (PR #136 in `teak-ios`), adapted for Android lifecycle.

## Key decisions

- **Refactored `RewardClaim` to store the eleven-key attribution as a `Map<String, Object>`** instead of a `Teak.AttributedLaunchData`. Click-time callers flatten launch data via `toMap()` once at start so both surfaces share the same fire/ack machinery. The launch-data-taking `startPoll` signature stays as a thin wrapper — no API churn for `TeakNotification.Reward`.
- **Refactored `RewardClaimResolvedEvent` to take the attribution map directly**; the inherited `Event.launchData` becomes `LaunchData.Unattributed` for this surface. Host games on resolved correlate via `event_id` and read the eleven attribution keys as discrete top-level fields off `toJSON()` — no separate `launchData` object is part of the documented surface here.
- **Tolerant `session_attribution` unpack**: accept either an inline `JSONObject` or a JSON-encoded string. The wire-format spec stores the blob as opaque text on the server; the SDK is robust to either taro encoding choice.
- **Sweep enrolls terminal entries into the in-flight dictionary** before firing resolved+ack, so the existing bounded retry budget and originating-session pin apply uniformly to both click-time and sweep entries.
- **Entry point**: `Session#setState`'s UserIdentified case body, after `processAttributionAndDispatchEvents`, gated on `this.state != State.Expiring` (evaluated when `this.state` is still the old-state value). The post-120s resume goes through `hasExpired → Expired → new Session → IdentifyingUser → UserIdentified`, so the gate filters the <120s flicker (`resetCurrentSessionToPreviousState`) without excluding the design's primary use case (player kicks off a server_jwt click, backgrounds long enough to cycle Session, foregrounds → sweep retrieves the customer-server resolution). Confirmed with ProductOps in `#issue-c-702` before coding.
- **Strip set on resolved-event userInfo**: aligns Android resolved-event strip set to iOS+JS canonical (post-C-724 / post-C-725) — only `session_attribution` and `teak_reward_id` are stripped before merging into the host-facing payload. `created_at`, `completed_at`, and the unpacked attribution keys are kept. Matches `Teak/TeakClaimPoll.m:118` and `teak.coffee:1902`. Applies uniformly to click-time and sweep terminal events.
- **C-721 inheritance**: the sweep's pending-poll cadence reads `claimPollInitialDelay` / `claimPollCeiling` from `RemoteConfiguration`, same as the click-time path.

## Test plan

- Spec-first commit (red) precedes the implementation (green); reviewer can read both diffs in sequence.
- `SessionStartSweepTests` adds 14 invariants on the dispatcher: attribution-map merge with strip set + keep-set assertions for `created_at`/`completed_at` + JSON-null normalization, terminal/pending in-flight registration, click-time dedupe, no `RewardClaimPendingEvent` re-fire on sweep, empty-list and malformed-entry tolerance, string-encoded `session_attribution` unpack (well-formed + malformed-string-tolerant), terminal entries enqueue `RewardClaimResolvedEvent`, and `startSweep` error-branch coverage (no-user, non-2xx, null body, unparseable/missing `claims` key).
- `RewardClickReplyDispatchTest` mock-Uri helper updated to stub `toString()` — the click-time path now flattens launch data via `DeepLink.willProcessUri` which calls `URI.create(toString())`.
- Full local run: 82 tests in `testDebugUnitTest`, all green. `./org_json_check` and `./check_thread_use` both pass.

## Readers left behind

- End-to-end `EventBus` delivery of the sweep's `RewardClaimResolvedEvent` is exercised at integration, not unit. The fire path goes through `whenUserIdIsReadyPost`, which queues until the test session reaches UserIdentified — not driven in the test environment. Helper-level coverage (`resolvedEvent_fromAttributionMap_mergesAttributionAndReply`, `sweep_terminalEntry_firesRewardClaimResolvedEvent` via reflection on `userIdReadyEventBusQueue`) plus the in-flight registration tests cover merge correctness and enrollment; the actual `EventBus.post` is integration-level.
