### PR TITLE
Android: auto-add Log events as Raven breadcrumbs

### DIFF
--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Sentry exception reports now include breadcrumbs from recent `Teak.log` events, making crashes easier to diagnose."

--- a/src/main/java/io/teak/sdk/Log.java
+++ b/src/main/java/io/teak/sdk/Log.java
@@ -20,6 +20,7 @@ import javax.net.ssl.HttpsURLConnection;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import io.teak.sdk.core.Executors;
 import io.teak.sdk.json.JSONObject;
 import io.teak.sdk.raven.Raven;
@@ -241,6 +242,7 @@ public class Log {
 });
 }
 
+@VisibleForTesting
 public void markConfigurationReady() {
     synchronized (queuedLogEvents) {
         processedQueuedLogEvents = true;

--- a/src/main/java/io/teak/sdk/Log.java
+++ b/src/main/java/io/teak/sdk/Log.java
@@ -186,7 +186,7 @@ public class Log {
     private boolean logTrace = false;
     private boolean sendToRapidIngestion;
 
-    private Raven sdkRaven;
+    private volatile Raven sdkRaven;
 
     public void setSdkRaven(Raven raven) {
         this.sdkRaven = raven;
@@ -232,12 +232,18 @@ public class Log {
 
                 synchronized (queuedLogEvents) {
             for (LogEvent event : queuedLogEvents) {
-                logEvent(event);
+                logEvent(event, null);
             }
             processedQueuedLogEvents = true;
                 }
     }
 });
+}
+
+public void markConfigurationReady() {
+    synchronized (queuedLogEvents) {
+        processedQueuedLogEvents = true;
+    }
 }
 
 public void useRapidIngestionEndpoint(boolean useRapidIngestionEndpoint) {
@@ -276,14 +282,14 @@ protected void log(final @NonNull Level logLevel, final @NonNull String eventTyp
     LogEvent logEvent = new LogEvent(logLevel, eventType, eventData);
     synchronized (queuedLogEvents) {
         if (processedQueuedLogEvents) {
-            this.logEvent(logEvent);
+            this.logEvent(logEvent, this.sdkRaven);
         } else {
             queuedLogEvents.add(logEvent);
         }
     }
 }
 
-private void logEvent(final @NonNull LogEvent logEvent) {
+private void logEvent(final @NonNull LogEvent logEvent, final @Nullable Raven currentRaven) {
     // Payload including common payload
     final Map<String, Object> payload = new HashMap<>(this.commonPayload);
 
@@ -361,8 +367,8 @@ private void logEvent(final @NonNull LogEvent logEvent) {
     }
 
     // Fan out to Raven breadcrumbs (skip "exception" — it creates its own report)
-    if (!logEvent.eventType.equals("exception") && this.sdkRaven != null) {
-        this.sdkRaven.addBreadcrumb(logEvent.logLevel.ravenLevelName, logEvent.eventType, logEvent.eventData);
+    if (!logEvent.eventType.equals("exception") && currentRaven != null) {
+        currentRaven.addBreadcrumb(logEvent.logLevel.ravenLevelName, logEvent.eventType, logEvent.eventData);
     }
 }
 }

--- a/src/main/java/io/teak/sdk/Log.java
+++ b/src/main/java/io/teak/sdk/Log.java
@@ -188,6 +188,7 @@ public class Log {
 
     private volatile Raven sdkRaven;
 
+    // Kept in sync with TeakInstance.sdkRaven by the TeakConfiguration listener in TeakInstance.
     public void setSdkRaven(Raven raven) {
         this.sdkRaven = raven;
     }

--- a/src/main/java/io/teak/sdk/Log.java
+++ b/src/main/java/io/teak/sdk/Log.java
@@ -51,16 +51,18 @@ import io.teak.sdk.raven.Raven;
 public class Log {
     // region Log Level enum
     private enum Level {
-        Info("INFO", android.util.Log.INFO),
-        Warn("WARN", android.util.Log.WARN),
-        Error("ERROR", android.util.Log.ERROR);
+        Info("INFO", android.util.Log.INFO, "info"),
+        Warn("WARN", android.util.Log.WARN, "warning"),
+        Error("ERROR", android.util.Log.ERROR, "error");
 
         public final String name;
         public final int androidLogPriority;
+        public final String ravenLevelName;
 
-        Level(String name, int androidLogPriority) {
+        Level(String name, int androidLogPriority, String ravenLevelName) {
             this.name = name;
             this.androidLogPriority = androidLogPriority;
+            this.ravenLevelName = ravenLevelName;
         }
     }
     // endregion
@@ -183,6 +185,12 @@ public class Log {
     private boolean logRemotely;
     private boolean logTrace = false;
     private boolean sendToRapidIngestion;
+
+    private Raven sdkRaven;
+
+    public void setSdkRaven(Raven raven) {
+        this.sdkRaven = raven;
+    }
 
     private Teak.LogListener logListener;
     // endregion
@@ -315,9 +323,9 @@ private void logEvent(final @NonNull LogEvent logEvent) {
                 connection.setUseCaches(false);
                 connection.setDoOutput(true);
                 connection.setRequestProperty("Content-Type", "application/json");
-                //connection.setRequestProperty("Content-Encoding", "gzip");
+                // connection.setRequestProperty("Content-Encoding", "gzip");
 
-                //GZIPOutputStream wr = new GZIPOutputStream(connection.getOutputStream());
+                // GZIPOutputStream wr = new GZIPOutputStream(connection.getOutputStream());
                 OutputStream wr = connection.getOutputStream();
                 wr.write(new JSONObject(payload).toString().getBytes());
                 wr.flush();
@@ -331,7 +339,7 @@ private void logEvent(final @NonNull LogEvent logEvent) {
                 }
                 BufferedReader rd = new BufferedReader(new InputStreamReader(is));
                 String line;
-                //noinspection MismatchedQueryAndUpdateOfStringBuilder
+                // noinspection MismatchedQueryAndUpdateOfStringBuilder
                 StringBuilder response = new StringBuilder();
                 while ((line = rd.readLine()) != null) {
                     response.append(line);
@@ -350,6 +358,11 @@ private void logEvent(final @NonNull LogEvent logEvent) {
     // Log to listeners
     if (this.logListener != null) {
         this.logListener.logEvent(logEvent.eventType, logEvent.logLevel.name, payload);
+    }
+
+    // Fan out to Raven breadcrumbs (skip "exception" — it creates its own report)
+    if (!logEvent.eventType.equals("exception") && this.sdkRaven != null) {
+        this.sdkRaven.addBreadcrumb(logEvent.logLevel.ravenLevelName, logEvent.eventType, logEvent.eventData);
     }
 }
 }

--- a/src/main/java/io/teak/sdk/TeakInstance.java
+++ b/src/main/java/io/teak/sdk/TeakInstance.java
@@ -53,7 +53,7 @@ public class TeakInstance implements Unobfuscable {
 
     @SuppressLint("ObsoleteSdkInt")
     TeakInstance(@NonNull Activity activity, @NonNull final IObjectFactory objectFactory) {
-        //noinspection all -- Disable warning on the null check
+        // noinspection all -- Disable warning on the null check
         if (activity == null) {
             throw new InvalidParameterException("null Activity passed to Teak.onCreate");
         }
@@ -67,6 +67,7 @@ public class TeakInstance implements Unobfuscable {
         // Ravens
         TeakConfiguration.addEventListener(configuration -> {
             TeakInstance.this.sdkRaven = new Raven(context, "sdk", configuration, objectFactory);
+            Teak.log.setSdkRaven(TeakInstance.this.sdkRaven);
             TeakInstance.this.appRaven = new Raven(context, configuration.appConfiguration.bundleId, configuration, objectFactory);
         });
 
@@ -475,7 +476,7 @@ public class TeakInstance implements Unobfuscable {
         Paused("Paused"),
         Destroyed("Destroyed");
 
-        //public static final Integer length = 1 + Destroyed.ordinal();
+        // public static final Integer length = 1 + Destroyed.ordinal();
 
         private static final State[][] allowedTransitions = {
             {},

--- a/src/main/java/io/teak/sdk/raven/Raven.java
+++ b/src/main/java/io/teak/sdk/raven/Raven.java
@@ -402,12 +402,11 @@ public class Raven implements Thread.UncaughtExceptionHandler {
                 payload.putAll(additions);
             }
 
-            synchronized (Raven.this.breadcrumbs) {
-                if (!Raven.this.breadcrumbs.isEmpty()) {
-                    final HashMap<String, Object> breadcrumbsPayload = new HashMap<>();
-                    breadcrumbsPayload.put("values", new ArrayList<>(Raven.this.breadcrumbs));
-                    payload.put("breadcrumbs", breadcrumbsPayload);
-                }
+            final List<Map<String, Object>> breadcrumbSnapshot = Raven.this.snapshotBreadcrumbs();
+            if (!breadcrumbSnapshot.isEmpty()) {
+                final HashMap<String, Object> breadcrumbsPayload = new HashMap<>();
+                breadcrumbsPayload.put("values", breadcrumbSnapshot);
+                payload.put("breadcrumbs", breadcrumbsPayload);
             }
         }
 

--- a/src/main/java/io/teak/sdk/raven/Raven.java
+++ b/src/main/java/io/teak/sdk/raven/Raven.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.text.SimpleDateFormat;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -18,6 +19,7 @@ import java.util.TimeZone;
 import java.util.UUID;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.work.Constraints;
 import androidx.work.Data;
 import androidx.work.ExistingWorkPolicy;
@@ -61,6 +63,9 @@ public class Raven implements Thread.UncaughtExceptionHandler {
         }
     }
 
+    private static final int BREADCRUMB_LIMIT = 100;
+    private final ArrayDeque<Map<String, Object>> breadcrumbs = new ArrayDeque<>();
+
     private final List<Report> queuedReports = new ArrayList<>();
     private final HashMap<String, Object> payloadTemplate = new HashMap<>();
     private final Context applicationContext;
@@ -78,7 +83,7 @@ public class Raven implements Thread.UncaughtExceptionHandler {
     }
 
     public Raven(@NonNull Context context, @NonNull String appId, @NonNull TeakConfiguration configuration, @NonNull IObjectFactory objectFactory) {
-        //noinspection deprecation - This must be a string as per Sentry API
+        // noinspection deprecation - This must be a string as per Sentry API
         @SuppressWarnings("deprecation")
         final String teakSdkVersion = Teak.SDKVersion;
 
@@ -318,6 +323,29 @@ public class Raven implements Thread.UncaughtExceptionHandler {
         }
     }
 
+    public void addBreadcrumb(@NonNull String level, @NonNull String message, @Nullable Map<String, Object> data) {
+        final HashMap<String, Object> breadcrumb = new HashMap<>();
+        breadcrumb.put("timestamp", Raven.timestampFormatter.format(new Date()));
+        breadcrumb.put("level", level);
+        breadcrumb.put("category", level);
+        breadcrumb.put("message", message);
+        if (data != null) {
+            breadcrumb.put("data", data);
+        }
+        synchronized (this.breadcrumbs) {
+            this.breadcrumbs.addLast(breadcrumb);
+            if (this.breadcrumbs.size() > BREADCRUMB_LIMIT) {
+                this.breadcrumbs.removeFirst();
+            }
+        }
+    }
+
+    public List<Map<String, Object>> snapshotBreadcrumbs() {
+        synchronized (this.breadcrumbs) {
+            return new ArrayList<>(this.breadcrumbs);
+        }
+    }
+
     private Map<String, Object> toMap() {
         HashMap<String, Object> ret = new HashMap<>();
         ret.put("appId", this.appId);
@@ -363,15 +391,23 @@ public class Raven implements Thread.UncaughtExceptionHandler {
                 final int depth = 4;
                 final StackTraceElement[] ste = Thread.currentThread().getStackTrace();
                 payload.put("culprit", ste[depth].toString());
-                //for (StackTraceElement elem : ste) {
-                //    Log.d(LOG_TAG, elem.toString());
-                //}
+                // for (StackTraceElement elem : ste) {
+                //     Log.d(LOG_TAG, elem.toString());
+                // }
             } catch (Exception e) {
                 payload.put("culprit", "unknown");
             }
 
             if (additions != null) {
                 payload.putAll(additions);
+            }
+
+            synchronized (Raven.this.breadcrumbs) {
+                if (!Raven.this.breadcrumbs.isEmpty()) {
+                    final HashMap<String, Object> breadcrumbsPayload = new HashMap<>();
+                    breadcrumbsPayload.put("values", new ArrayList<>(Raven.this.breadcrumbs));
+                    payload.put("breadcrumbs", breadcrumbsPayload);
+                }
             }
         }
 

--- a/src/main/java/io/teak/sdk/raven/Raven.java
+++ b/src/main/java/io/teak/sdk/raven/Raven.java
@@ -327,7 +327,7 @@ public class Raven implements Thread.UncaughtExceptionHandler {
         final HashMap<String, Object> breadcrumb = new HashMap<>();
         breadcrumb.put("timestamp", Raven.timestampFormatter.format(new Date()));
         breadcrumb.put("level", level);
-        breadcrumb.put("category", level);
+        breadcrumb.put("category", message);
         breadcrumb.put("message", message);
         if (data != null) {
             breadcrumb.put("data", data);

--- a/test_app/app/src/test/java/io/teak/app/test/NotificationBroadcastReceivers.java
+++ b/test_app/app/src/test/java/io/teak/app/test/NotificationBroadcastReceivers.java
@@ -34,11 +34,23 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class NotificationBroadcastReceivers {
+    private Log originalTeakLog;
+    private Field teakLogField;
+
+    @org.junit.After
+    public void restoreTeakLog() throws NoSuchFieldException, IllegalAccessException {
+        if (teakLogField != null && originalTeakLog != null) {
+            teakLogField.set(null, originalTeakLog);
+        }
+    }
+
     @Test
     public void FcmMessageReceieved() throws PackageManager.NameNotFoundException, NoSuchFieldException, IllegalAccessException {
-        final Log teakLog = mock(Log.class); // withSettings().verboseLogging()
-        final Field teakLogField = Teak.class.getDeclaredField("log");
+        teakLogField = Teak.class.getDeclaredField("log");
         teakLogField.setAccessible(true);
+        originalTeakLog = (Log) teakLogField.get(null);
+
+        final Log teakLog = mock(Log.class); // withSettings().verboseLogging()
         teakLogField.set(null, teakLog);
 
         final TestTeakEventListener eventListener = spy(TestTeakEventListener.class);

--- a/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
@@ -1,0 +1,84 @@
+package io.teak.app.test;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+import io.teak.sdk.Log;
+import io.teak.sdk.Teak;
+import io.teak.sdk.TeakConfiguration;
+import io.teak.sdk.raven.Raven;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RavenBreadcrumbTest extends TeakUnitTest {
+
+    @After
+    public void tearDown() {
+        Teak.log.setSdkRaven(null);
+    }
+
+    private static void markLogQueueReady() throws Exception {
+        Field f = Log.class.getDeclaredField("processedQueuedLogEvents");
+        f.setAccessible(true);
+        f.set(Teak.log, true);
+    }
+
+    private Raven makeRaven() throws Exception {
+        final Raven[] holder = {null};
+        TeakConfiguration.addEventListener(config -> holder[0] = new Raven(context, "sdk", config, objectFactory));
+        markLogQueueReady();
+        return holder[0];
+    }
+
+    @Test
+    public void logIFiresBreadcrumb() throws Exception {
+        Raven raven = makeRaven();
+        Teak.log.setSdkRaven(raven);
+
+        Teak.log.i("test.breadcrumb", "hello breadcrumbs");
+
+        List<Map<String, Object>> breadcrumbs = raven.snapshotBreadcrumbs();
+        assertFalse(breadcrumbs.isEmpty());
+
+        Map<String, Object> crumb = breadcrumbs.get(breadcrumbs.size() - 1);
+        assertEquals("test.breadcrumb", crumb.get("message"));
+        assertEquals("info", crumb.get("level"));
+        assertTrue(crumb.containsKey("timestamp"));
+    }
+
+    @Test
+    public void breadcrumbCapAt100() throws Exception {
+        Raven raven = makeRaven();
+
+        for (int i = 0; i < 110; i++) {
+            raven.addBreadcrumb("info", "event." + i, null);
+        }
+
+        List<Map<String, Object>> breadcrumbs = raven.snapshotBreadcrumbs();
+        assertEquals(100, breadcrumbs.size());
+        assertEquals("event.10", breadcrumbs.get(0).get("message"));
+        assertEquals("event.109", breadcrumbs.get(99).get("message"));
+    }
+
+    @Test
+    public void exceptionEventNotAddedAsBreadcrumb() throws Exception {
+        Raven raven = makeRaven();
+        Teak.log.setSdkRaven(raven);
+
+        Teak.log.exception(new RuntimeException("test"), false);
+
+        List<Map<String, Object>> breadcrumbs = raven.snapshotBreadcrumbs();
+        for (Map<String, Object> crumb : breadcrumbs) {
+            assertFalse("exception".equals(crumb.get("message")));
+        }
+    }
+}

--- a/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
@@ -5,11 +5,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 
-import io.teak.sdk.Log;
 import io.teak.sdk.Teak;
 import io.teak.sdk.TeakConfiguration;
 import io.teak.sdk.raven.Raven;
@@ -26,23 +24,19 @@ public class RavenBreadcrumbTest extends TeakUnitTest {
         Teak.log.setSdkRaven(null);
     }
 
-    private static void markLogQueueReady() throws Exception {
-        Field f = Log.class.getDeclaredField("processedQueuedLogEvents");
-        f.setAccessible(true);
-        f.set(Teak.log, true);
-    }
-
     private Raven makeRaven() throws Exception {
         final Raven[] holder = {null};
         TeakConfiguration.addEventListener(config -> holder[0] = new Raven(context, "sdk", config, objectFactory));
-        markLogQueueReady();
+        Teak.log.markConfigurationReady();
         return holder[0];
     }
 
     @Test
     public void logIFiresBreadcrumb() throws Exception {
-        Raven raven = makeRaven();
+        // setSdkRaven before markConfigurationReady establishes happens-before through queuedLogEvents monitor
+        Raven raven = new Raven(context, "sdk", TeakConfiguration.get(), objectFactory);
         Teak.log.setSdkRaven(raven);
+        Teak.log.markConfigurationReady();
 
         Teak.log.i("test.breadcrumb", "hello breadcrumbs");
 

--- a/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
@@ -24,16 +24,12 @@ public class RavenBreadcrumbTest extends TeakUnitTest {
         Teak.log.setSdkRaven(null);
     }
 
-    private Raven makeRaven() throws Exception {
-        final Raven[] holder = {null};
-        TeakConfiguration.addEventListener(config -> holder[0] = new Raven(context, "sdk", config, objectFactory));
-        Teak.log.markConfigurationReady();
-        return holder[0];
+    private Raven makeRaven() {
+        return new Raven(context, "sdk", TeakConfiguration.get(), objectFactory);
     }
 
     @Test
     public void logIFiresBreadcrumb() throws Exception {
-        // setSdkRaven before markConfigurationReady establishes happens-before through queuedLogEvents monitor
         Raven raven = new Raven(context, "sdk", TeakConfiguration.get(), objectFactory);
         Teak.log.setSdkRaven(raven);
         Teak.log.markConfigurationReady();
@@ -45,6 +41,7 @@ public class RavenBreadcrumbTest extends TeakUnitTest {
 
         Map<String, Object> crumb = breadcrumbs.get(breadcrumbs.size() - 1);
         assertEquals("test.breadcrumb", crumb.get("message"));
+        assertEquals("test.breadcrumb", crumb.get("category"));
         assertEquals("info", crumb.get("level"));
         assertTrue(crumb.containsKey("timestamp"));
     }


### PR DESCRIPTION
Closes https://linear.app/teakio/issue/C-684/android-sdk-auto-add-log-events-as-raven-breadcrumbs

## Summary

Sentry exception reports from the Android SDK previously had no breadcrumb trail. Every `Log.i`/`Log.e`/`Log.w` call now fans out to Raven as a breadcrumb, giving crashes the same context iOS has had. Breadcrumbs are capped at 100 entries (FIFO), snapshotted at report creation time, and included under `breadcrumbs.values` in the Sentry payload. Exception log events are excluded from their own report's breadcrumb list.

## Key decisions

- Snapshot breadcrumbs in `Report` constructor (not `toData()`) so the trail reflects state at throw time, not serialization time.
- Skip `eventType == "exception"` rather than timing the snapshot around `reportException`, which is simpler and spec-endorsed.
- `Log` holds a direct `Raven` reference (`setSdkRaven()`) instead of reaching into `Teak.Instance.sdkRaven` — avoids coupling and enables clean unit testing without mocking `TeakInstance` (which has a transitive Facebook SDK dep).

## Test plan

`(cd test_app && ./gradlew testDebugUnitTest)` — all 41 tests pass, including 3 new: `logIFiresBreadcrumb`, `breadcrumbCapAt100`, `exceptionEventNotAddedAsBreadcrumb`.

🤖 Generated with [Claude Code](https://claude.ai/code)