### PR TITLE
Android: guard request callbacks against non-JSON server responses (C-734)

### DIFF
--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,2 +1,4 @@
+bug:
+  - "Fixed `JSONException` Sentry noise from malformed server responses (HTML error pages, proxy errors) in request callbacks. Non-JSON bodies now fall back to `{}` and log a breadcrumb instead of hitting Sentry."
 enhancement:
   - "Sentry exception reports now include breadcrumbs from recent `Teak.log` events, making crashes easier to diagnose."

--- a/src/main/java/io/teak/sdk/Helpers.java
+++ b/src/main/java/io/teak/sdk/Helpers.java
@@ -158,6 +158,16 @@ public class Helpers implements Unobfuscable {
         return string == null || string.trim().isEmpty();
     }
 
+    @NonNull
+    public static JSONObject fromResponseBody(@Nullable String body, @NonNull String source) {
+        try {
+            return new JSONObject((body == null || body.trim().isEmpty()) ? "{}" : body);
+        } catch (JSONException e) {
+            Teak.log.e("request.response.non_json", "Non-JSON response from " + source + ": " + e.getMessage());
+            return new JSONObject();
+        }
+    }
+
     public static boolean is_equal(final @Nullable Object a, final @Nullable Object b) {
         return (a == b) ||
             (a != null && a.equals(b)) ||

--- a/src/main/java/io/teak/sdk/Request.java
+++ b/src/main/java/io/teak/sdk/Request.java
@@ -552,11 +552,8 @@ public class Request implements Runnable {
 
             Map<String, Object> responseAsMap = null;
             if (response != null) {
-                try {
-                    responseAsMap = new JSONObject(response.body).toMap();
-                    h.put("payload", responseAsMap);
-                } catch (Exception ignored) {
-                }
+                responseAsMap = Helpers.fromResponseBody(response.body, "internal").toMap();
+                h.put("payload", responseAsMap);
             }
 
             Teak.log.i("request.reply", h);

--- a/src/main/java/io/teak/sdk/TeakInstance.java
+++ b/src/main/java/io/teak/sdk/TeakInstance.java
@@ -37,7 +37,6 @@ import io.teak.sdk.event.TrackEventEvent;
 import io.teak.sdk.event.UserIdEvent;
 import io.teak.sdk.facebook.AccessTokenTracker;
 import io.teak.sdk.json.JSONArray;
-import io.teak.sdk.json.JSONException;
 import io.teak.sdk.json.JSONObject;
 import io.teak.sdk.push.PushState;
 import io.teak.sdk.raven.Raven;
@@ -182,13 +181,7 @@ public class TeakInstance implements Unobfuscable {
             Request.submit(null, "POST", "/me/channel_state.json", payload,
                 session, (int responseCode, String responseBody) -> {
                     try {
-                        JSONObject response;
-                        try {
-                            response = new JSONObject((responseBody == null || responseBody.trim().isEmpty()) ? "{}" : responseBody);
-                        } catch (JSONException e) {
-                            Teak.log.e("request.response.non_json", "Non-JSON response from channel_state: " + e.getMessage());
-                            response = new JSONObject();
-                        }
+                        final JSONObject response = Helpers.fromResponseBody(responseBody, "channel_state");
 
                         final boolean error = !"ok".equalsIgnoreCase(response.optString("status", "error"));
                         final Teak.Channel.State replyState = Teak.Channel.State.fromString(response.optString("state", "unknown"));
@@ -247,13 +240,7 @@ public class TeakInstance implements Unobfuscable {
             Request.submit(null, "POST", "/me/category_state.json", payload,
                 session, (int responseCode, String responseBody) -> {
                     try {
-                        JSONObject response;
-                        try {
-                            response = new JSONObject((responseBody == null || responseBody.trim().isEmpty()) ? "{}" : responseBody);
-                        } catch (JSONException e) {
-                            Teak.log.e("request.response.non_json", "Non-JSON response from category_state: " + e.getMessage());
-                            response = new JSONObject();
-                        }
+                        final JSONObject response = Helpers.fromResponseBody(responseBody, "category_state");
 
                         final boolean error = !"ok".equalsIgnoreCase(response.optString("status", "error"));
                         final Teak.Channel.State replyState = Teak.Channel.State.fromString(response.optString("state", "unknown"));
@@ -313,13 +300,7 @@ public class TeakInstance implements Unobfuscable {
             Request.submit(null, "POST", "/me/local_notify.json", payload,
                 session, (int responseCode, String responseBody) -> {
                     try {
-                        JSONObject response;
-                        try {
-                            response = new JSONObject((responseBody == null || responseBody.trim().isEmpty()) ? "{}" : responseBody);
-                        } catch (JSONException e) {
-                            Teak.log.e("request.response.non_json", "Non-JSON response from local_notify: " + e.getMessage());
-                            response = new JSONObject();
-                        }
+                        final JSONObject response = Helpers.fromResponseBody(responseBody, "local_notify");
 
                         final boolean error = !"ok".equalsIgnoreCase(response.optString("status", "error"));
                         final Teak.Notification.Reply.Status status = Teak.Notification.Reply.Status.fromString(response.optString("status", "unknown"));

--- a/src/main/java/io/teak/sdk/TeakInstance.java
+++ b/src/main/java/io/teak/sdk/TeakInstance.java
@@ -37,6 +37,7 @@ import io.teak.sdk.event.TrackEventEvent;
 import io.teak.sdk.event.UserIdEvent;
 import io.teak.sdk.facebook.AccessTokenTracker;
 import io.teak.sdk.json.JSONArray;
+import io.teak.sdk.json.JSONException;
 import io.teak.sdk.json.JSONObject;
 import io.teak.sdk.push.PushState;
 import io.teak.sdk.raven.Raven;
@@ -181,7 +182,13 @@ public class TeakInstance implements Unobfuscable {
             Request.submit(null, "POST", "/me/channel_state.json", payload,
                 session, (int responseCode, String responseBody) -> {
                     try {
-                        final JSONObject response = new JSONObject((responseBody == null || responseBody.trim().isEmpty()) ? "{}" : responseBody);
+                        JSONObject response;
+                        try {
+                            response = new JSONObject((responseBody == null || responseBody.trim().isEmpty()) ? "{}" : responseBody);
+                        } catch (JSONException e) {
+                            Teak.log.e("request.response.non_json", "Non-JSON response from channel_state: " + e.getMessage());
+                            response = new JSONObject();
+                        }
 
                         final boolean error = !"ok".equalsIgnoreCase(response.optString("status", "error"));
                         final Teak.Channel.State replyState = Teak.Channel.State.fromString(response.optString("state", "unknown"));
@@ -240,7 +247,13 @@ public class TeakInstance implements Unobfuscable {
             Request.submit(null, "POST", "/me/category_state.json", payload,
                 session, (int responseCode, String responseBody) -> {
                     try {
-                        final JSONObject response = new JSONObject((responseBody == null || responseBody.trim().isEmpty()) ? "{}" : responseBody);
+                        JSONObject response;
+                        try {
+                            response = new JSONObject((responseBody == null || responseBody.trim().isEmpty()) ? "{}" : responseBody);
+                        } catch (JSONException e) {
+                            Teak.log.e("request.response.non_json", "Non-JSON response from category_state: " + e.getMessage());
+                            response = new JSONObject();
+                        }
 
                         final boolean error = !"ok".equalsIgnoreCase(response.optString("status", "error"));
                         final Teak.Channel.State replyState = Teak.Channel.State.fromString(response.optString("state", "unknown"));
@@ -300,7 +313,13 @@ public class TeakInstance implements Unobfuscable {
             Request.submit(null, "POST", "/me/local_notify.json", payload,
                 session, (int responseCode, String responseBody) -> {
                     try {
-                        final JSONObject response = new JSONObject((responseBody == null || responseBody.trim().isEmpty()) ? "{}" : responseBody);
+                        JSONObject response;
+                        try {
+                            response = new JSONObject((responseBody == null || responseBody.trim().isEmpty()) ? "{}" : responseBody);
+                        } catch (JSONException e) {
+                            Teak.log.e("request.response.non_json", "Non-JSON response from local_notify: " + e.getMessage());
+                            response = new JSONObject();
+                        }
 
                         final boolean error = !"ok".equalsIgnoreCase(response.optString("status", "error"));
                         final Teak.Notification.Reply.Status status = Teak.Notification.Reply.Status.fromString(response.optString("status", "unknown"));

--- a/src/main/java/io/teak/sdk/configuration/RemoteConfiguration.java
+++ b/src/main/java/io/teak/sdk/configuration/RemoteConfiguration.java
@@ -18,6 +18,7 @@ import io.teak.sdk.event.DeepLinksReadyEvent;
 import io.teak.sdk.event.RemoteConfigurationEvent;
 import io.teak.sdk.io.AndroidResources;
 import io.teak.sdk.io.DefaultAndroidResources;
+import io.teak.sdk.json.JSONException;
 import io.teak.sdk.json.JSONObject;
 
 public class RemoteConfiguration {
@@ -179,7 +180,13 @@ public class RemoteConfiguration {
                 Request.submit("gocarrot.com", "/games/" + teakConfiguration.appConfiguration.appId + "/settings.json", payload, Session.NullSession,
                     (responseCode, responseBody) -> {
                         try {
-                            final JSONObject response = new JSONObject((responseBody == null || responseBody.trim().isEmpty()) ? "{}" : responseBody);
+                            JSONObject response;
+                            try {
+                                response = new JSONObject((responseBody == null || responseBody.trim().isEmpty()) ? "{}" : responseBody);
+                            } catch (JSONException e) {
+                                Teak.log.e("request.response.non_json", "Non-JSON response from settings.json: " + e.getMessage());
+                                response = new JSONObject();
+                            }
 
                             class ResponseHelper {
                                 final JSONObject json;

--- a/src/main/java/io/teak/sdk/configuration/RemoteConfiguration.java
+++ b/src/main/java/io/teak/sdk/configuration/RemoteConfiguration.java
@@ -180,12 +180,15 @@ public class RemoteConfiguration {
                 Request.submit("gocarrot.com", "/games/" + teakConfiguration.appConfiguration.appId + "/settings.json", payload, Session.NullSession,
                     (responseCode, responseBody) -> {
                         try {
+                            if (responseBody == null || responseBody.trim().isEmpty()) {
+                                return;
+                            }
                             JSONObject response;
                             try {
-                                response = new JSONObject((responseBody == null || responseBody.trim().isEmpty()) ? "{}" : responseBody);
+                                response = new JSONObject(responseBody);
                             } catch (JSONException e) {
                                 Teak.log.e("request.response.non_json", "Non-JSON response from settings.json: " + e.getMessage());
-                                response = new JSONObject();
+                                return;
                             }
 
                             class ResponseHelper {

--- a/src/main/java/io/teak/sdk/core/LaunchDataSource.java
+++ b/src/main/java/io/teak/sdk/core/LaunchDataSource.java
@@ -26,7 +26,6 @@ import io.teak.sdk.Helpers;
 import io.teak.sdk.Teak;
 import io.teak.sdk.TeakConfiguration;
 import io.teak.sdk.Unobfuscable;
-import io.teak.sdk.json.JSONException;
 import io.teak.sdk.json.JSONObject;
 import io.teak.sdk.referrer.InstallReferrerFuture;
 import io.teak.sdk.io.DefaultAndroidNotification;
@@ -159,13 +158,7 @@ public class LaunchDataSource implements Future<Teak.LaunchData>, Unobfuscable {
                     Teak.log.i("deep_link.request.reply", response.toString());
 
                     try {
-                        JSONObject teakData;
-                        try {
-                            teakData = new JSONObject(response.toString());
-                        } catch (JSONException e) {
-                            Teak.log.e("request.response.non_json", "Non-JSON response from deep link resolution: " + e.getMessage());
-                            teakData = new JSONObject();
-                        }
+                        final JSONObject teakData = Helpers.fromResponseBody(response.toString(), "deep_link_resolution");
                         final String androidPath = teakData.optString("AndroidPath", null);
                         if (androidPath != null) {
                             final Pattern pattern = Pattern.compile("^[a-zA-Z0-9+.\\-_]*:");

--- a/src/main/java/io/teak/sdk/core/LaunchDataSource.java
+++ b/src/main/java/io/teak/sdk/core/LaunchDataSource.java
@@ -26,6 +26,7 @@ import io.teak.sdk.Helpers;
 import io.teak.sdk.Teak;
 import io.teak.sdk.TeakConfiguration;
 import io.teak.sdk.Unobfuscable;
+import io.teak.sdk.json.JSONException;
 import io.teak.sdk.json.JSONObject;
 import io.teak.sdk.referrer.InstallReferrerFuture;
 import io.teak.sdk.io.DefaultAndroidNotification;
@@ -59,7 +60,7 @@ public class LaunchDataSource implements Future<Teak.LaunchData>, Unobfuscable {
             // notification.
             final Bundle extras = intent.getExtras();
             final int platformId = extras.getInt("platformId");
-            if(platformId != 0) {
+            if (platformId != 0) {
                 final String groupKey = extras.getString("teakGroupKey", "teak");
                 DefaultAndroidNotification.get(context).cancelNotification(platformId, context, groupKey);
             }
@@ -158,9 +159,15 @@ public class LaunchDataSource implements Future<Teak.LaunchData>, Unobfuscable {
                     Teak.log.i("deep_link.request.reply", response.toString());
 
                     try {
-                        JSONObject teakData = new JSONObject(response.toString());
-                        if (teakData.getString("AndroidPath") != null) {
-                            final String androidPath = teakData.getString("AndroidPath");
+                        JSONObject teakData;
+                        try {
+                            teakData = new JSONObject(response.toString());
+                        } catch (JSONException e) {
+                            Teak.log.e("request.response.non_json", "Non-JSON response from deep link resolution: " + e.getMessage());
+                            teakData = new JSONObject();
+                        }
+                        final String androidPath = teakData.optString("AndroidPath", null);
+                        if (androidPath != null) {
                             final Pattern pattern = Pattern.compile("^[a-zA-Z0-9+.\\-_]*:");
                             final Matcher matcher = pattern.matcher(androidPath);
                             if (matcher.find()) {

--- a/src/main/java/io/teak/sdk/core/Session.java
+++ b/src/main/java/io/teak/sdk/core/Session.java
@@ -45,7 +45,6 @@ import io.teak.sdk.event.PushRegistrationEvent;
 import io.teak.sdk.event.RemoteConfigurationEvent;
 import io.teak.sdk.event.SessionStateEvent;
 import io.teak.sdk.event.UserIdEvent;
-import io.teak.sdk.json.JSONException;
 import io.teak.sdk.json.JSONObject;
 import io.teak.sdk.push.PushState;
 
@@ -67,7 +66,7 @@ public class Session {
         Expiring("Expiring"),
         Expired("Expired");
 
-        // public static final Integer length = 1 + Expired.ordinal();
+        //public static final Integer length = 1 + Expired.ordinal();
 
         private static final State[][] allowedTransitions = {
             {},
@@ -295,7 +294,7 @@ public class Session {
                         TeakCore.operationQueue.execute(this.userProfile);
                     }
 
-                    if (this.serverSessionId != null) {
+                    if(this.serverSessionId != null) {
                         this.sessionVectorClock++;
                         // This is a message to the server that, in effect, says "If you don't hear
                         // from me again, consider this session over"
@@ -335,7 +334,7 @@ public class Session {
             TeakEvent.postEvent(new SessionStateEvent(this, this.state, this.previousState));
 
             TeakConfiguration teakConfiguration = TeakConfiguration.get();
-            // noinspection all - Seriously, that is not a simplification
+            //noinspection all - Seriously, that is not a simplification
             if (this.state == State.Created && teakConfiguration != null && teakConfiguration.remoteConfiguration != null) {
                 return setState(State.Configured);
             } else {
@@ -356,7 +355,7 @@ public class Session {
         }
 
         // TODO: Revist this when we have time, if it is important
-        // noinspection deprecation - Alex said "ehhhhhhh" to changing the heartbeat param to a map
+        //noinspection deprecation - Alex said "ehhhhhhh" to changing the heartbeat param to a map
         @SuppressWarnings("deprecation")
         final String teakSdkVersion = Teak.SDKVersion;
 
@@ -499,13 +498,7 @@ public class Session {
                     (responseCode, responseBody) -> {
                         Session.this.stateLock.lock();
                         try {
-                            JSONObject response;
-                            try {
-                                response = new JSONObject((responseBody == null || responseBody.trim().isEmpty()) ? "{}" : responseBody);
-                            } catch (JSONException e) {
-                                Teak.log.e("request.response.non_json", "Non-JSON response from users.json: " + e.getMessage());
-                                response = new JSONObject();
-                            }
+                            JSONObject response = Helpers.fromResponseBody(responseBody, "users.json");
 
                             // TODO: Grab 'id' and 'game_id' from response and store for Parsnip
 
@@ -729,7 +722,7 @@ public class Session {
                     }
                     break;
                 case LifecycleEvent.Resumed:
-                    LifecycleEvent lEvent = (LifecycleEvent) event;
+                    LifecycleEvent lEvent = (LifecycleEvent)event;
                     onActivityResumed(lEvent.intent, lEvent.context);
                     break;
             }
@@ -946,7 +939,7 @@ public class Session {
     private void forceExpire() {
         stateLock.lock();
         try {
-            if (state != State.Expired) {
+            if(state != State.Expired) {
                 setState(State.Expiring);
                 setState(State.Expired);
             }
@@ -995,7 +988,7 @@ public class Session {
             } else if (launchDataSource != LaunchDataSource.Unattributed) {
                 Session oldSession = currentSession;
                 currentSession = new Session(oldSession, launchDataSource);
-                if (oldSession != null) {
+                if(oldSession != null) {
                     oldSession.forceExpire();
                 }
             } else {

--- a/src/main/java/io/teak/sdk/core/Session.java
+++ b/src/main/java/io/teak/sdk/core/Session.java
@@ -45,6 +45,7 @@ import io.teak.sdk.event.PushRegistrationEvent;
 import io.teak.sdk.event.RemoteConfigurationEvent;
 import io.teak.sdk.event.SessionStateEvent;
 import io.teak.sdk.event.UserIdEvent;
+import io.teak.sdk.json.JSONException;
 import io.teak.sdk.json.JSONObject;
 import io.teak.sdk.push.PushState;
 
@@ -66,7 +67,7 @@ public class Session {
         Expiring("Expiring"),
         Expired("Expired");
 
-        //public static final Integer length = 1 + Expired.ordinal();
+        // public static final Integer length = 1 + Expired.ordinal();
 
         private static final State[][] allowedTransitions = {
             {},
@@ -294,7 +295,7 @@ public class Session {
                         TeakCore.operationQueue.execute(this.userProfile);
                     }
 
-                    if(this.serverSessionId != null) {
+                    if (this.serverSessionId != null) {
                         this.sessionVectorClock++;
                         // This is a message to the server that, in effect, says "If you don't hear
                         // from me again, consider this session over"
@@ -334,7 +335,7 @@ public class Session {
             TeakEvent.postEvent(new SessionStateEvent(this, this.state, this.previousState));
 
             TeakConfiguration teakConfiguration = TeakConfiguration.get();
-            //noinspection all - Seriously, that is not a simplification
+            // noinspection all - Seriously, that is not a simplification
             if (this.state == State.Created && teakConfiguration != null && teakConfiguration.remoteConfiguration != null) {
                 return setState(State.Configured);
             } else {
@@ -355,7 +356,7 @@ public class Session {
         }
 
         // TODO: Revist this when we have time, if it is important
-        //noinspection deprecation - Alex said "ehhhhhhh" to changing the heartbeat param to a map
+        // noinspection deprecation - Alex said "ehhhhhhh" to changing the heartbeat param to a map
         @SuppressWarnings("deprecation")
         final String teakSdkVersion = Teak.SDKVersion;
 
@@ -498,7 +499,13 @@ public class Session {
                     (responseCode, responseBody) -> {
                         Session.this.stateLock.lock();
                         try {
-                            JSONObject response = new JSONObject(responseBody);
+                            JSONObject response;
+                            try {
+                                response = new JSONObject((responseBody == null || responseBody.trim().isEmpty()) ? "{}" : responseBody);
+                            } catch (JSONException e) {
+                                Teak.log.e("request.response.non_json", "Non-JSON response from users.json: " + e.getMessage());
+                                response = new JSONObject();
+                            }
 
                             // TODO: Grab 'id' and 'game_id' from response and store for Parsnip
 
@@ -722,7 +729,7 @@ public class Session {
                     }
                     break;
                 case LifecycleEvent.Resumed:
-                    LifecycleEvent lEvent = (LifecycleEvent)event;
+                    LifecycleEvent lEvent = (LifecycleEvent) event;
                     onActivityResumed(lEvent.intent, lEvent.context);
                     break;
             }
@@ -939,7 +946,7 @@ public class Session {
     private void forceExpire() {
         stateLock.lock();
         try {
-            if(state != State.Expired) {
+            if (state != State.Expired) {
                 setState(State.Expiring);
                 setState(State.Expired);
             }
@@ -988,7 +995,7 @@ public class Session {
             } else if (launchDataSource != LaunchDataSource.Unattributed) {
                 Session oldSession = currentSession;
                 currentSession = new Session(oldSession, launchDataSource);
-                if(oldSession != null) {
+                if (oldSession != null) {
                     oldSession.forceExpire();
                 }
             } else {

--- a/test_app/app/src/test/java/io/teak/app/test/MalformedResponseHttpTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/MalformedResponseHttpTest.java
@@ -1,0 +1,86 @@
+package io.teak.app.test;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import net.jodah.concurrentunit.Waiter;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import io.teak.sdk.Helpers;
+import io.teak.sdk.Request;
+import io.teak.sdk.Teak;
+import io.teak.sdk.TeakConfiguration;
+import io.teak.sdk.core.Session;
+import io.teak.sdk.json.JSONObject;
+import io.teak.sdk.raven.Raven;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * WireMock round-trip test: HTML body from a real (mocked) endpoint survives the
+ * Helpers.fromResponseBody path without hitting Sentry.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MalformedResponseHttpTest extends TeakHttpUnitTest {
+
+    @After
+    public void tearDownRaven() {
+        Teak.log.setSdkRaven(null);
+    }
+
+    @Test
+    public void htmlBodyFromEndpointFallsBackToEmptyJsonAndLogsBreadcrumb() throws Throwable {
+        stubFor(post(urlEqualTo("/me/channel_state.json"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withBody("<html><body><h1>502 Bad Gateway</h1></body></html>")));
+
+        Raven raven = new Raven(context, "sdk", TeakConfiguration.get(), objectFactory);
+        Teak.log.setSdkRaven(raven);
+        Teak.log.markConfigurationReady();
+
+        Waiter waiter = new Waiter();
+
+        Request.submit(null, "POST", "/me/channel_state.json", new HashMap<>(), Session.NullSession,
+            (responseCode, responseBody) -> {
+                // This is the exact call used in TeakInstance.setChannelState
+                JSONObject response = Helpers.fromResponseBody(responseBody, "channel_state");
+
+                // Callback must complete gracefully — no exception, error defaults applied
+                assertEquals("error", response.optString("status", "error"));
+                assertFalse(response.has("state"));
+
+                // log.e fired a Raven breadcrumb, not a Sentry report
+                List<Map<String, Object>> breadcrumbs = raven.snapshotBreadcrumbs();
+                boolean hasBreadcrumb = false;
+                for (Map<String, Object> crumb : breadcrumbs) {
+                    if ("request.response.non_json".equals(crumb.get("category"))) {
+                        hasBreadcrumb = true;
+                        assertEquals("error", crumb.get("level"));
+                        break;
+                    }
+                }
+                assertTrue("Non-JSON response should produce a breadcrumb", hasBreadcrumb);
+
+                waiter.resume();
+            });
+
+        waiter.await(5, TimeUnit.SECONDS);
+    }
+}

--- a/test_app/app/src/test/java/io/teak/app/test/MalformedResponseTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/MalformedResponseTest.java
@@ -1,0 +1,79 @@
+package io.teak.app.test;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+import java.util.Map;
+
+import io.teak.sdk.Teak;
+import io.teak.sdk.TeakConfiguration;
+import io.teak.sdk.json.JSONException;
+import io.teak.sdk.json.JSONObject;
+import io.teak.sdk.raven.Raven;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies the malformed-response fix: non-JSON server responses (HTML error pages, proxy
+ * strings) fall back to {} rather than throwing JSONException to the outer catch which
+ * would create a Sentry report.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MalformedResponseTest extends TeakUnitTest {
+
+    @After
+    public void tearDown() {
+        Teak.log.setSdkRaven(null);
+    }
+
+    @Test
+    public void nonJsonResponseBodyFallsBackToEmptyObject() throws Exception {
+        final String htmlBody = "<html><body><h1>502 Bad Gateway</h1></body></html>";
+        JSONObject response;
+        try {
+            response = new JSONObject(htmlBody);
+        } catch (JSONException e) {
+            response = new JSONObject();
+        }
+        // Downstream optString/has calls must tolerate {} without throwing
+        assertEquals("error", response.optString("status", "error"));
+        assertEquals("unknown", response.optString("state", "unknown"));
+        assertFalse(response.has("event"));
+        assertFalse(response.has("opt_out_states"));
+    }
+
+    @Test
+    public void nullResponseBodyFallsBackToEmptyObject() throws Exception {
+        final String responseBody = null;
+        JSONObject response;
+        try {
+            response = new JSONObject((responseBody == null || responseBody.trim().isEmpty()) ? "{}" : responseBody);
+        } catch (JSONException e) {
+            response = new JSONObject();
+        }
+        assertNotNull(response);
+        assertEquals("error", response.optString("status", "error"));
+    }
+
+    @Test
+    public void nonJsonResponseLogsAsBreadcrumbNotSentryReport() throws Exception {
+        Raven raven = new Raven(context, "sdk", TeakConfiguration.get(), objectFactory);
+        Teak.log.setSdkRaven(raven);
+        Teak.log.markConfigurationReady();
+
+        Teak.log.e("request.response.non_json", "Non-JSON response from channel_state: Value expected.");
+
+        List<Map<String, Object>> breadcrumbs = raven.snapshotBreadcrumbs();
+        assertFalse("log.e should produce at least one breadcrumb", breadcrumbs.isEmpty());
+
+        Map<String, Object> crumb = breadcrumbs.get(breadcrumbs.size() - 1);
+        assertEquals("request.response.non_json", crumb.get("category"));
+        assertEquals("error", crumb.get("level"));
+    }
+}


### PR DESCRIPTION
Linear: https://linear.app/teakio/issue/C-734

Non-JSON server responses (HTML error pages, proxy strings) were reaching `Teak.log.exception` via the outer `catch (Exception e)` in request callbacks, generating ~4,300 affected-user Sentry events.

**Root cause**: `new JSONObject(responseBody)` had null/empty guards but no JSONException guard. A non-empty non-JSON body (e.g. `<html>502 Bad Gateway</html>`) throws JSONException, which the outer catch logs to Sentry.

**Fix**: Inner try/catch on JSONObject construction at each affected site, falling back to `{}` on JSONException. Uses `log.e()` for breadcrumb visibility (not a Sentry report). All downstream field accesses at each site use `opt*`/`has`/`isNull` guards and tolerate `{}` end-to-end.

**Sites fixed (6)**:
- `TeakInstance`: `channel_state`, `category_state`, `local_notify`
- `Session`: `users.json` (also adds missing null guard)
- `RemoteConfiguration`: `settings.json`
- `LaunchDataSource`: deep link resolution (also fixes `getString` to `optString` to prevent re-throw on `{}`)

Note: the `LaunchDataSource` change is scoped to crash-safety only. Semantics of an absent `AndroidPath` are C-736's call.