### PR TITLE
Android: silence expected transient errors from Sentry (C-738)

### DIFF
--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,2 +1,5 @@
+bug:
+  - "Silence expected transient errors (FCM unavailability, Android 7.x OkHttp NPE, DeadSystemException, notification build failures) from Sentry to reduce noise."
+
 enhancement:
   - "Sentry exception reports now include breadcrumbs from recent `Teak.log` events, making crashes easier to diagnose."

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,5 +1,2 @@
-bug:
-  - "Silence expected transient errors (FCM unavailability, Android 7.x OkHttp NPE, DeadSystemException, notification build failures) from Sentry to reduce noise."
-
 enhancement:
   - "Sentry exception reports now include breadcrumbs from recent `Teak.log` events, making crashes easier to diagnose."

--- a/src/main/java/io/teak/sdk/NotificationBuilder.java
+++ b/src/main/java/io/teak/sdk/NotificationBuilder.java
@@ -284,6 +284,14 @@ public class NotificationBuilder {
 
     }
 
+    private static boolean isHostAppDebug() {
+        try {
+            return TeakConfiguration.get().debugConfiguration.isDebug();
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
     public static Notification createNativeNotification(Context context, TeakNotification teakNotificaton) throws AssetLoadException {
         if (teakNotificaton.notificationVersion == TeakNotification.TEAK_NOTIFICATION_V0) {
             return null;
@@ -298,8 +306,9 @@ public class NotificationBuilder {
             if (teakNotificaton.teakCreativeName != null) {
                 extras.put("teakCreativeName", teakNotificaton.teakCreativeName);
             }
-            // Layout/RemoteViews quirks (e.g. Android 15) are outside our control — log locally only.
-            Teak.log.exception(e, extras, false);
+            // Layout/RemoteViews quirks (e.g. Android 15) are outside our control — suppress in
+            // production. Report in debug builds so our own bugs remain visible during QA.
+            Teak.log.exception(e, extras, isHostAppDebug());
 
             // TODO: Report to the 'callback' URL on the push when/if we implement that
             return null;
@@ -815,8 +824,9 @@ public class NotificationBuilder {
                 if (teakNotificaton.teakCreativeName != null) {
                     extras.put("teakCreativeName", teakNotificaton.teakCreativeName);
                 }
-                // Big content view failures (CDN, RemoteViews quirks) are outside our control — log locally only.
-                Teak.log.exception(e, extras, false);
+                // Big content view failures (CDN, RemoteViews quirks) are outside our control — suppress in
+                // production. Report in debug builds so our own bugs remain visible during QA.
+                Teak.log.exception(e, extras, isHostAppDebug());
             }
         }
 

--- a/src/main/java/io/teak/sdk/NotificationBuilder.java
+++ b/src/main/java/io/teak/sdk/NotificationBuilder.java
@@ -298,7 +298,8 @@ public class NotificationBuilder {
             if (teakNotificaton.teakCreativeName != null) {
                 extras.put("teakCreativeName", teakNotificaton.teakCreativeName);
             }
-            Teak.log.exception(e, extras);
+            // Layout/RemoteViews quirks (e.g. Android 15) are outside our control — log locally only.
+            Teak.log.exception(e, extras, false);
 
             // TODO: Report to the 'callback' URL on the push when/if we implement that
             return null;
@@ -814,7 +815,8 @@ public class NotificationBuilder {
                 if (teakNotificaton.teakCreativeName != null) {
                     extras.put("teakCreativeName", teakNotificaton.teakCreativeName);
                 }
-                Teak.log.exception(e, extras);
+                // Big content view failures (CDN, RemoteViews quirks) are outside our control — log locally only.
+                Teak.log.exception(e, extras, false);
             }
         }
 

--- a/src/main/java/io/teak/sdk/Request.java
+++ b/src/main/java/io/teak/sdk/Request.java
@@ -575,9 +575,27 @@ public class Request implements Runnable {
             }
 
             this.onRequestCompleted(statusCode, body);
+        } catch (NullPointerException e) {
+            // com.android.okhttp is an Android system lib (API < 27); no typed handle exists.
+            // Top-of-stack class prefix is the only available discriminator for this Android 7.x bug.
+            if (isOkhttpNpe(e)) {
+                Teak.log.i("request.error_transient", Helpers.mm.h("error", e.toString()));
+            } else {
+                Teak.log.exception(e);
+            }
         } catch (Exception e) {
-            Teak.log.exception(e);
+            // DeadSystemException added in API 24 — typed instanceof check is safe.
+            if (android.os.Build.VERSION.SDK_INT >= 24 && e instanceof android.os.DeadSystemException) {
+                Teak.log.i("request.error_transient", Helpers.mm.h("error", e.toString()));
+            } else {
+                Teak.log.exception(e);
+            }
         }
+    }
+
+    static boolean isOkhttpNpe(NullPointerException e) {
+        final StackTraceElement[] frames = e.getStackTrace();
+        return frames.length > 0 && frames[0].getClassName().startsWith("com.android.okhttp");
     }
 
     protected void onRequestCompleted(int responseCode, String responseBody) {

--- a/src/main/java/io/teak/sdk/push/FCMPushProvider.java
+++ b/src/main/java/io/teak/sdk/push/FCMPushProvider.java
@@ -13,6 +13,8 @@ import com.google.firebase.messaging.RemoteMessage;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
 import androidx.annotation.NonNull;
 import io.teak.sdk.Helpers;
@@ -150,7 +152,13 @@ public class FCMPushProvider extends FirebaseMessagingService implements IPushPr
                 final Task<String> instanceIdTask = FirebaseMessaging.getInstance().getToken();
                 instanceIdTask.addOnSuccessListener(this::onNewToken);
 
-                instanceIdTask.addOnFailureListener(e -> Teak.log.exception(e));
+                instanceIdTask.addOnFailureListener(e -> {
+                    if (isTransientFcmError(e)) {
+                        Teak.log.i("google.fcm.token_failure_transient", Helpers.mm.h("error", e.getMessage()));
+                    } else {
+                        Teak.log.exception(e);
+                    }
+                });
 
                 // Log out the Firebase config
                 final FirebaseOptions firebaseOptions = this.firebaseApp.getOptions();
@@ -163,6 +171,22 @@ public class FCMPushProvider extends FirebaseMessagingService implements IPushPr
                 Teak.log.exception(e);
             }
         }
+    }
+
+    // Firebase client contract: SERVICE_NOT_AVAILABLE / MISSING_INSTANCEID_SERVICE / FIS_AUTH_ERROR
+    // are delivered as IOException with the code as the message string — no typed getter on the
+    // client side, getMessage()-matching is the documented fingerprint.
+    // TimeoutException and ExecutionException(transient-cause) are infra-level, not bugs.
+    static boolean isTransientFcmError(Exception e) {
+        if (e instanceof TimeoutException) return true;
+        if (e instanceof ExecutionException) {
+            final Throwable cause = e.getCause();
+            return cause instanceof Exception && isTransientFcmError((Exception) cause);
+        }
+        final String msg = e.getMessage();
+        return msg != null && (msg.equals("SERVICE_NOT_AVAILABLE") ||
+                               msg.equals("MISSING_INSTANCEID_SERVICE") ||
+                               msg.equals("FIS_AUTH_ERROR"));
     }
 
     ///// Beware of the Leopard

--- a/src/main/java/io/teak/sdk/push/FCMPushProvider.java
+++ b/src/main/java/io/teak/sdk/push/FCMPushProvider.java
@@ -20,6 +20,7 @@ import androidx.annotation.NonNull;
 import io.teak.sdk.Helpers;
 import io.teak.sdk.IntegrationChecker;
 import io.teak.sdk.Teak;
+import io.teak.sdk.TeakConfiguration;
 import io.teak.sdk.TeakEvent;
 import io.teak.sdk.Unobfuscable;
 import io.teak.sdk.core.TeakCore;
@@ -153,7 +154,8 @@ public class FCMPushProvider extends FirebaseMessagingService implements IPushPr
                 instanceIdTask.addOnSuccessListener(this::onNewToken);
 
                 instanceIdTask.addOnFailureListener(e -> {
-                    if (isTransientFcmError(e)) {
+                    // In debug builds, always report so fingerprint misses are visible in QA.
+                    if (isTransientFcmError(e) && !isHostAppDebug()) {
                         Teak.log.i("google.fcm.token_failure_transient", Helpers.mm.h("error", e.toString()));
                     } else {
                         Teak.log.exception(e);
@@ -170,6 +172,14 @@ public class FCMPushProvider extends FirebaseMessagingService implements IPushPr
             } catch (Exception e) {
                 Teak.log.exception(e);
             }
+        }
+    }
+
+    private static boolean isHostAppDebug() {
+        try {
+            return TeakConfiguration.get().debugConfiguration.isDebug();
+        } catch (Exception ignored) {
+            return false;
         }
     }
 

--- a/src/main/java/io/teak/sdk/push/FCMPushProvider.java
+++ b/src/main/java/io/teak/sdk/push/FCMPushProvider.java
@@ -154,7 +154,7 @@ public class FCMPushProvider extends FirebaseMessagingService implements IPushPr
 
                 instanceIdTask.addOnFailureListener(e -> {
                     if (isTransientFcmError(e)) {
-                        Teak.log.i("google.fcm.token_failure_transient", Helpers.mm.h("error", e.getMessage()));
+                        Teak.log.i("google.fcm.token_failure_transient", Helpers.mm.h("error", e.toString()));
                     } else {
                         Teak.log.exception(e);
                     }

--- a/test_app/app/src/test/java/io/teak/sdk/OkhttpNpeTest.java
+++ b/test_app/app/src/test/java/io/teak/sdk/OkhttpNpeTest.java
@@ -1,0 +1,43 @@
+package io.teak.sdk;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class OkhttpNpeTest {
+
+    private static NullPointerException npeFromClass(String className) {
+        NullPointerException e = new NullPointerException("test");
+        StackTraceElement frame = new StackTraceElement(className, "doSomething", "Foo.java", 42);
+        e.setStackTrace(new StackTraceElement[] {frame});
+        return e;
+    }
+
+    @Test
+    public void okhttpNpe_isTransient() {
+        assertTrue(Request.isOkhttpNpe(npeFromClass("com.android.okhttp.internal.http.HttpEngine")));
+    }
+
+    @Test
+    public void okhttpSubpackageNpe_isTransient() {
+        assertTrue(Request.isOkhttpNpe(npeFromClass("com.android.okhttp.OkHttpClient")));
+    }
+
+    @Test
+    public void teakNpe_isNotTransient() {
+        assertFalse(Request.isOkhttpNpe(npeFromClass("io.teak.sdk.Request")));
+    }
+
+    @Test
+    public void androidNpe_isNotTransient() {
+        assertFalse(Request.isOkhttpNpe(npeFromClass("android.os.Handler")));
+    }
+
+    @Test
+    public void emptyStackTrace_isNotTransient() {
+        NullPointerException e = new NullPointerException("test");
+        e.setStackTrace(new StackTraceElement[] {});
+        assertFalse(Request.isOkhttpNpe(e));
+    }
+}

--- a/test_app/app/src/test/java/io/teak/sdk/push/TransientFcmErrorTest.java
+++ b/test_app/app/src/test/java/io/teak/sdk/push/TransientFcmErrorTest.java
@@ -1,0 +1,66 @@
+package io.teak.sdk.push;
+
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TransientFcmErrorTest {
+
+    @Test
+    public void timeoutException_isTransient() {
+        assertTrue(FCMPushProvider.isTransientFcmError(new TimeoutException()));
+    }
+
+    @Test
+    public void executionException_wrappingTimeout_isTransient() {
+        assertTrue(FCMPushProvider.isTransientFcmError(new ExecutionException(new TimeoutException())));
+    }
+
+    @Test
+    public void executionException_wrappingServiceNotAvailable_isTransient() {
+        assertTrue(FCMPushProvider.isTransientFcmError(
+            new ExecutionException(new Exception("SERVICE_NOT_AVAILABLE"))));
+    }
+
+    @Test
+    public void serviceNotAvailable_isTransient() {
+        assertTrue(FCMPushProvider.isTransientFcmError(new Exception("SERVICE_NOT_AVAILABLE")));
+    }
+
+    @Test
+    public void missingInstanceIdService_isTransient() {
+        assertTrue(FCMPushProvider.isTransientFcmError(new Exception("MISSING_INSTANCEID_SERVICE")));
+    }
+
+    @Test
+    public void fisAuthError_isTransient() {
+        assertTrue(FCMPushProvider.isTransientFcmError(new Exception("FIS_AUTH_ERROR")));
+    }
+
+    @Test
+    public void genericRuntimeException_isNotTransient() {
+        assertFalse(FCMPushProvider.isTransientFcmError(new RuntimeException("something broke")));
+    }
+
+    @Test
+    public void executionException_wrappingRealError_isNotTransient() {
+        assertFalse(FCMPushProvider.isTransientFcmError(
+            new ExecutionException(new RuntimeException("bad sender id"))));
+    }
+
+    @Test
+    public void illegalArgumentException_isNotTransient() {
+        // IAE was excluded — could indicate misconfiguration (bad google-services.json etc.)
+        assertFalse(FCMPushProvider.isTransientFcmError(new IllegalArgumentException("bad arg")));
+    }
+
+    @Test
+    public void partialCodeMatch_isNotTransient() {
+        // Substring of a known code should NOT match (we use equals, not contains)
+        assertFalse(FCMPushProvider.isTransientFcmError(new Exception("NOT_SERVICE_NOT_AVAILABLE")));
+    }
+}


### PR DESCRIPTION
Linear: https://linear.app/teakio/issue/C-738/android-silence-expected-transient-errors-from-sentry-fcmnetworksystem

Three catch sites flooding Sentry with ~40 noise issues from failures outside our control.

**FCMPushProvider** — `addOnFailureListener` now routes to `Teak.log.i` for known transient FCM codes (`SERVICE_NOT_AVAILABLE`, `MISSING_INSTANCEID_SERVICE`, `FIS_AUTH_ERROR`, `TimeoutException`, `ExecutionException` wrapping those); non-transient still goes to Sentry. Classifier is unit-tested with positive and negative cases.

**Request.run** outer catch — `NullPointerException` from `com.android.okhttp` (Android 7.x system lib, no typed handle — top-of-stack prefix check with comment) and `DeadSystemException` (typed `instanceof`, API 24+) log locally only. Everything else still reports.

**NotificationBuilder** — generic layout/RemoteViews failures in `createNativeNotification` and the `bigContentView` path changed to `reportToRaven=false`. `AssetLoadException` rethrow is preserved so `RetriableTask`'s 3x retry still runs for CDN image fetches.

---

**Scope note: IllegalArgumentException deliberately excluded from FCM filter.**
C-738 lists `IllegalArgumentException` (old Firebase SDK PendingIntent bug) among the transient types to silence. This PR excludes it by design: there is no stable class or stack signature to narrow the match, so a blanket IAE silence would also hide real Firebase config errors (bad google-services.json, bad sender ID) — silent push breakage with zero Sentry signal. Net: any IAE-sourced issues in the ~40 Sentry list stay un-silenced. Needs explicit human sign-off on this narrower scope.