### PR TITLE
Android: stop reward-claim NPE with UNKNOWN sentinel (C-733)

### DIFF
--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,2 +1,5 @@
+bug:
+  - "Fixed a crash (NPE) when claiming a reward if the server response was empty or had an unexpected shape. `TeakNotification.Reward.rewardFromRewardId` now resolves to a reward with `UNKNOWN` status instead of crashing or hanging."
+
 enhancement:
   - "Sentry exception reports now include breadcrumbs from recent `Teak.log` events, making crashes easier to diagnose."

--- a/src/main/java/io/teak/sdk/TeakNotification.java
+++ b/src/main/java/io/teak/sdk/TeakNotification.java
@@ -172,8 +172,82 @@ public class TeakNotification implements Unobfuscable {
         private static final String EXPIRED_STRING = "expired";
         private static final String INVALID_POST_STRING = "invalid_post";
 
+        // Sentinel returned when a reward-claim response can't be interpreted, so callers get a
+        // non-null UNKNOWN reward instead of a crash (C-733). The json carries teakRewardId and a
+        // status string because the Unity/Cocos wrappers index json["teakRewardId"]/json["status"]
+        // directly — a bare {} would just move the crash downstream into a KeyNotFoundException.
+        static Reward unknownReward(final String teakRewardId) {
+            final JSONObject json = new JSONObject();
+            try {
+                json.put("teakRewardId", teakRewardId);
+                json.put("status", "unknown");
+            } catch (JSONException ignored) {
+                // A constant key plus the already-validated, non-null teakRewardId never throws.
+            }
+            return new Reward(json);
+        }
+
+        // Reported (non-fatal) to Sentry when a 200 reward-claim response is missing the structure we
+        // expect. Each shape is reported from a distinct site so Sentry groups them separately, with
+        // the raw body in `extra`, to root-cause which responses are arriving (C-733).
+        private static class UnexpectedRewardResponseException extends Exception implements Unobfuscable {
+            UnexpectedRewardResponseException(@NonNull String message) {
+                super(message);
+            }
+        }
+
+        // Turns a reward-claim response body into a Reward. Never returns null: an empty, malformed,
+        // or unexpectedly-shaped response yields an UNKNOWN sentinel (and, for the valid-JSON-but-
+        // wrong-shape cases, a non-fatal Sentry report carrying the body) so the caller's queue and
+        // the Unity/Cocos wrappers always get a usable reward (C-733).
+        static Reward rewardFromClaimResponse(final String teakRewardId, final String responseBody) {
+            try {
+                if (responseBody == null) {
+                    Teak.log.exception(new UnexpectedRewardResponseException("Reward claim response body was null."),
+                        mm.h("teakRewardId", teakRewardId));
+                    return unknownReward(teakRewardId);
+                }
+
+                final JSONObject responseJson = new JSONObject(responseBody);
+
+                final JSONObject rewardResponse = responseJson.optJSONObject("response");
+                if (rewardResponse == null) {
+                    Teak.log.exception(new UnexpectedRewardResponseException("Reward claim response missing 'response' object."),
+                        mm.h("teakRewardId", teakRewardId, "response", responseBody));
+                    return unknownReward(teakRewardId);
+                }
+
+                if (rewardResponse.isNull("status")) {
+                    Teak.log.exception(new UnexpectedRewardResponseException("Reward claim response missing 'status'."),
+                        mm.h("teakRewardId", teakRewardId, "response", responseBody));
+                    return unknownReward(teakRewardId);
+                }
+
+                final JSONObject fullParsedResponse = new JSONObject();
+                fullParsedResponse.put("teakRewardId", teakRewardId);
+                fullParsedResponse.put("status", rewardResponse.get("status"));
+                if (rewardResponse.optJSONObject("reward") != null) {
+                    fullParsedResponse.put("reward", rewardResponse.get("reward"));
+                } else if (rewardResponse.opt("reward") != null) {
+                    fullParsedResponse.put("reward", new JSONObject(rewardResponse.getString("reward")));
+                }
+
+                Teak.log.i("reward.claim.response", responseJson.toMap());
+
+                return new Reward(fullParsedResponse);
+            } catch (JSONException e) {
+                Teak.log.exception(e, false);
+                return unknownReward(teakRewardId);
+            } catch (Exception e) {
+                Teak.log.exception(e);
+                return unknownReward(teakRewardId);
+            }
+        }
+
         /**
-         * @return A {@link Future} which will contain the reward that should be granted, or <code>null</code> if there is no associated reward.
+         * @return A {@link Future} which resolves to the {@link Reward} for the given id. On an
+         *         unexpected or unparseable response the reward will have {@link Reward#UNKNOWN}
+         *         status rather than being <code>null</code>.
          */
         @SuppressWarnings("unused")
         public static Future<Reward> rewardFromRewardId(final String teakRewardId) {
@@ -210,51 +284,10 @@ public class TeakNotification implements Unobfuscable {
                     payload.put("clicking_user_id", session.userId());
 
                     Request.submit("rewards.gocarrot.com", "/" + teakRewardId + "/clicks", payload, session,
-                        (responseCode, responseBody) -> {
-                            try {
-                                final JSONObject responseJson = new JSONObject(responseBody);
-
-                                // https://sentry.io/organizations/teak/issues/1354507192/?project=141792&referrer=alert_email
-                                if (responseBody == null) {
-                                    q.offer(null);
-                                    return;
-                                }
-
-                                final JSONObject rewardResponse = responseJson.optJSONObject("response");
-                                if (rewardResponse == null) {
-                                    q.offer(null);
-                                    return;
-                                }
-
-                                if (rewardResponse.get("status") == null) {
-                                    q.offer(null);
-                                    return;
-                                }
-
-                                final JSONObject fullParsedResponse = new JSONObject();
-                                fullParsedResponse.put("teakRewardId", teakRewardId);
-                                fullParsedResponse.put("status", rewardResponse.get("status"));
-                                if (rewardResponse.optJSONObject("reward") != null) {
-                                    fullParsedResponse.put("reward", rewardResponse.get("reward"));
-                                } else if (rewardResponse.opt("reward") != null) {
-                                    fullParsedResponse.put("reward", new JSONObject(rewardResponse.getString("reward")));
-                                }
-                                final Reward reward = new Reward(fullParsedResponse);
-
-                                Teak.log.i("reward.claim.response", responseJson.toMap());
-
-                                q.offer(reward);
-                            } catch (JSONException e) {
-                                Teak.log.exception(e, false);
-                                q.offer(null);
-                            } catch (Exception e) {
-                                Teak.log.exception(e);
-                                q.offer(null); // TODO: Fix this?
-                            }
-                        });
+                        (responseCode, responseBody) -> q.offer(rewardFromClaimResponse(teakRewardId, responseBody)));
                 } catch (Exception e) {
                     Teak.log.exception(e);
-                    q.offer(null); // TODO: Fix this?
+                    q.offer(unknownReward(teakRewardId));
                 }
             });
 

--- a/src/main/java/io/teak/sdk/TeakNotification.java
+++ b/src/main/java/io/teak/sdk/TeakNotification.java
@@ -172,27 +172,31 @@ public class TeakNotification implements Unobfuscable {
         private static final String EXPIRED_STRING = "expired";
         private static final String INVALID_POST_STRING = "invalid_post";
 
-        // Sentinel returned when a reward-claim response can't be interpreted, so callers get a
-        // non-null UNKNOWN reward instead of a crash (C-733). The json mirrors the success-path shape
-        // (teakRewardId + status) so downstream consumers don't choke on a bare {}: the Unity/Cocos
-        // wrappers index json["status"] directly (a missing key throws KeyNotFoundException), and
-        // direct public-API callers read teakRewardId straight off the reward json. (In the wrapper
-        // RewardClaim path teakRewardId also comes from launchData, so there status is the key that
-        // would otherwise be absent.)
+        // Wire value the iOS SDK already emits when a claim response has no usable status; not a
+        // server status, so it deliberately isn't in the mapping above and collapses to UNKNOWN.
+        private static final String INTERNAL_ERROR_STATUS = "internal_error";
+
+        // Sentinel for a reward-claim response we can't interpret: callers get a non-null reward
+        // instead of a crash. The json mirrors the success-path shape — status "internal_error"
+        // (the string the iOS SDK already emits for this case, which teak-unity maps to its
+        // InternalError status) plus teakRewardId — so a bare {} doesn't choke downstream: the
+        // Unity/Cocos wrappers index json["status"] directly (a missing key throws
+        // KeyNotFoundException), and direct public-API callers read teakRewardId off the reward json.
+        // The native Reward ctor collapses the unrecognized "internal_error" string to UNKNOWN.
         static Reward unknownReward(final String teakRewardId) {
             final JSONObject json = new JSONObject();
             try {
                 json.put("teakRewardId", teakRewardId);
-                json.put("status", "unknown");
+                json.put("status", INTERNAL_ERROR_STATUS);
             } catch (JSONException ignored) {
                 // A constant key plus the already-validated, non-null teakRewardId never throws.
             }
             return new Reward(json);
         }
 
-        // Reported (non-fatal) to Sentry when a 200 reward-claim response is missing the structure we
+        // Reported (non-fatal) to Sentry when a reward-claim response is missing the structure we
         // expect. Each shape is reported from a distinct site so Sentry groups them separately, with
-        // the raw body in `extra`, to root-cause which responses are arriving (C-733).
+        // the raw body in `extra`, to surface which responses are actually arriving.
         private static class UnexpectedRewardResponseException extends Exception implements Unobfuscable {
             UnexpectedRewardResponseException(@NonNull String message) {
                 super(message);
@@ -202,7 +206,7 @@ public class TeakNotification implements Unobfuscable {
         // Turns a reward-claim response body into a Reward. Never returns null: an empty, malformed,
         // or unexpectedly-shaped response yields an UNKNOWN sentinel (and, for the valid-JSON-but-
         // wrong-shape cases, a non-fatal Sentry report carrying the body) so the caller's queue and
-        // the Unity/Cocos wrappers always get a usable reward (C-733).
+        // the Unity/Cocos wrappers always get a usable reward.
         static Reward rewardFromClaimResponse(final String teakRewardId, final String responseBody) {
             try {
                 if (responseBody == null) {

--- a/src/main/java/io/teak/sdk/TeakNotification.java
+++ b/src/main/java/io/teak/sdk/TeakNotification.java
@@ -173,9 +173,12 @@ public class TeakNotification implements Unobfuscable {
         private static final String INVALID_POST_STRING = "invalid_post";
 
         // Sentinel returned when a reward-claim response can't be interpreted, so callers get a
-        // non-null UNKNOWN reward instead of a crash (C-733). The json carries teakRewardId and a
-        // status string because the Unity/Cocos wrappers index json["teakRewardId"]/json["status"]
-        // directly — a bare {} would just move the crash downstream into a KeyNotFoundException.
+        // non-null UNKNOWN reward instead of a crash (C-733). The json mirrors the success-path shape
+        // (teakRewardId + status) so downstream consumers don't choke on a bare {}: the Unity/Cocos
+        // wrappers index json["status"] directly (a missing key throws KeyNotFoundException), and
+        // direct public-API callers read teakRewardId straight off the reward json. (In the wrapper
+        // RewardClaim path teakRewardId also comes from launchData, so there status is the key that
+        // would otherwise be absent.)
         static Reward unknownReward(final String teakRewardId) {
             final JSONObject json = new JSONObject();
             try {

--- a/test_app/app/src/test/java/io/teak/sdk/RewardClaimResponseTest.java
+++ b/test_app/app/src/test/java/io/teak/sdk/RewardClaimResponseTest.java
@@ -9,9 +9,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * C-733: reward-claim responses must never crash or hang. Every parse outcome yields a non-null
- * Reward whose json always carries teakRewardId + status, because the Unity/Cocos wrappers index
- * both keys directly and would KeyNotFoundException on a bare {}.
+ * Reward-claim responses must never crash or hang. Every parse outcome yields a non-null Reward
+ * whose json always carries teakRewardId + status — the wrappers index json["status"] directly and
+ * would KeyNotFoundException on a bare {}, and direct callers read teakRewardId off the json.
  *
  * Lives in io.teak.sdk so it can reach the package-private parse helper without standing up a
  * full session / WireMock path.
@@ -34,7 +34,8 @@ public class RewardClaimResponseTest {
         final Reward reward = Reward.unknownReward(REWARD_ID);
         assertEquals(Reward.UNKNOWN, reward.status);
         assertEquals(REWARD_ID, reward.json.getString("teakRewardId"));
-        assertTrue(reward.json.has("status"));
+        // Reuses the iOS wire value so teak-unity maps it to RewardStatus.InternalError.
+        assertEquals("internal_error", reward.json.getString("status"));
     }
 
     @Test

--- a/test_app/app/src/test/java/io/teak/sdk/RewardClaimResponseTest.java
+++ b/test_app/app/src/test/java/io/teak/sdk/RewardClaimResponseTest.java
@@ -1,0 +1,81 @@
+package io.teak.sdk;
+
+import org.junit.Test;
+
+import io.teak.sdk.TeakNotification.Reward;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * C-733: reward-claim responses must never crash or hang. Every parse outcome yields a non-null
+ * Reward whose json always carries teakRewardId + status, because the Unity/Cocos wrappers index
+ * both keys directly and would KeyNotFoundException on a bare {}.
+ *
+ * Lives in io.teak.sdk so it can reach the package-private parse helper without standing up a
+ * full session / WireMock path.
+ */
+public class RewardClaimResponseTest {
+    private static final String REWARD_ID = "test-reward-id";
+
+    // Parses a body and asserts the invariants that hold for *every* outcome.
+    private static Reward parse(String body) {
+        final Reward reward = Reward.rewardFromClaimResponse(REWARD_ID, body);
+        assertNotNull(reward);
+        assertNotNull(reward.json);
+        assertTrue("json must carry teakRewardId for the wrappers", reward.json.has("teakRewardId"));
+        assertTrue("json must carry status for the wrappers", reward.json.has("status"));
+        return reward;
+    }
+
+    @Test
+    public void unknownSentinelIsWrapperSafe() throws Exception {
+        final Reward reward = Reward.unknownReward(REWARD_ID);
+        assertEquals(Reward.UNKNOWN, reward.status);
+        assertEquals(REWARD_ID, reward.json.getString("teakRewardId"));
+        assertTrue(reward.json.has("status"));
+    }
+
+    @Test
+    public void nullBodyYieldsUnknown() {
+        assertEquals(Reward.UNKNOWN, parse(null).status);
+    }
+
+    @Test
+    public void unparseableBodyYieldsUnknown() {
+        assertEquals(Reward.UNKNOWN, parse("this is not json").status);
+    }
+
+    @Test
+    public void missingResponseObjectYieldsUnknown() {
+        assertEquals(Reward.UNKNOWN, parse("{\"foo\":\"bar\"}").status);
+    }
+
+    @Test
+    public void missingStatusYieldsUnknown() {
+        assertEquals(Reward.UNKNOWN, parse("{\"response\":{}}").status);
+    }
+
+    @Test
+    public void unrecognizedStatusYieldsUnknown() {
+        assertEquals(Reward.UNKNOWN, parse("{\"response\":{\"status\":\"bananas\"}}").status);
+    }
+
+    @Test
+    public void grantRewardParsesWithReward() {
+        final Reward reward = parse("{\"response\":{\"status\":\"grant_reward\",\"reward\":{\"coins\":10}}}");
+        assertEquals(Reward.GRANT_REWARD, reward.status);
+        assertTrue(reward.json.has("reward"));
+    }
+
+    @Test
+    public void selfClickParses() {
+        assertEquals(Reward.SELF_CLICK, parse("{\"response\":{\"status\":\"self_click\"}}").status);
+    }
+
+    @Test
+    public void alreadyClickedParses() {
+        assertEquals(Reward.ALREADY_CLICKED, parse("{\"response\":{\"status\":\"already_clicked\"}}").status);
+    }
+}


### PR DESCRIPTION
Linear: https://linear.app/teakio/issue/C-733/android-investigate-unexpected-reward-claim-api-responses-npe-in

## What

Stops the `rewardFromRewardId` NPE (Sentry `TEAK-ANDROID-SDK-2EE` / `-2EY`, ~5.3k users) and keeps the investigation alive.

The queue is an `ArrayBlockingQueue<Reward>`, which rejects `null`, so every error path's `q.offer(null)` threw NPE (the crash) **and** left the `Future` unresolved — hanging the session execution thread too. All error paths now offer an `UNKNOWN` sentinel reward instead.

## Changes

- Extracted response parsing into a package-private `rewardFromClaimResponse(teakRewardId, responseBody)` helper that **never returns null** — empty / malformed / unexpectedly-shaped responses yield an `UNKNOWN` sentinel.
- Sentinel `json` carries `teakRewardId` + a `status` string. The Unity/Cocos wrappers index `json["teakRewardId"]` and `json["status"]` directly, so a bare `{}` would just move the crash downstream into a `KeyNotFoundException`.
- Valid-JSON-but-wrong-shape paths (null body, missing `response`, missing `status`) fire a **non-fatal Sentry report** (`UnexpectedRewardResponseException`, constructed not thrown so the stack is captured) with the raw body in `extra`, to root-cause which 200-shapes are arriving. Distinct sites group separately in Sentry (the 2EE/2EY split shows this project groups by stack position).
- Reordered the dead `responseBody == null` check above the `JSONObject` parse, and folded the dead `get("status") == null` into a real `isNull` guard.
- The unparseable-JSON `catch` stays `reportToRaven=false` (transient-network noise, not the documented mystery).

## Testing

- New `RewardClaimResponseTest` (in `io.teak.sdk` for package-private access) — covers the sentinel shape + every parse outcome without a live session. 9 cases, all green.
- Full `testDebugUnitTest` suite green; AAR assembles; `org_json_check` + `check_thread_use` pass.

## Notes

- This is the "quick workaround" half of C-733: stop the crash, capture the shapes. Root-causing which response trips the early-return paths continues from the new Sentry reports (+ C-684 breadcrumbs).
