### PR TITLE
Move run_id from Sentry user to tags; normalize name from log_run_id

### DIFF
--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -4,3 +4,4 @@ bug:
 
 enhancement:
   - "Sentry exception reports now include breadcrumbs from recent `Teak.log` events, making crashes easier to diagnose."
+  - "The `run_id` correlation ID is now a Sentry tag (was a `user` field), making it searchable/filterable in the Sentry UI and consistent with the TeakLog event payload key."

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -4,4 +4,3 @@ bug:
 
 enhancement:
   - "Sentry exception reports now include breadcrumbs from recent `Teak.log` events, making crashes easier to diagnose."
-  - "The `run_id` correlation ID is now a Sentry tag (was a `user` field), making it searchable/filterable in the Sentry UI and consistent with the TeakLog event payload key."

--- a/src/main/java/io/teak/sdk/raven/Raven.java
+++ b/src/main/java/io/teak/sdk/raven/Raven.java
@@ -154,7 +154,6 @@ public class Raven implements Thread.UncaughtExceptionHandler {
 
         final HashMap<String, Object> user = new HashMap<>();
         user.put("device_id", configuration.deviceConfiguration.deviceId);
-        user.put("log_run_id", Teak.log.runId); // Run id is always available
         this.payloadTemplate.put("user", user);
 
         TeakEvent.addEventListener(event -> {
@@ -167,6 +166,7 @@ public class Raven implements Thread.UncaughtExceptionHandler {
         tagsAttribute.put("app_id", configuration.appConfiguration.appId);
         tagsAttribute.put("app_version", configuration.appConfiguration.appVersion);
         tagsAttribute.put("app_version_name", configuration.appConfiguration.appVersionName);
+        tagsAttribute.put("run_id", Teak.log.runId);
         this.payloadTemplate.put("tags", tagsAttribute);
     }
 


### PR DESCRIPTION
Moves the per-run correlation ID from the Sentry `user` object to `tags` (where Sentry indexes it for search/filter), and renames it from `log_run_id` → `run_id` to match the TeakLog event payload key.

**Both** things happen here: the field moves AND the name normalizes. Anyone with saved Sentry searches or queries on `user.log_run_id` will need to update them — per the issue's AC, this should be verified before merge.

Linear: https://linear.app/teakio/issue/C-685