### PR TITLE
Fix UnsatisfiedLinkError suppression in TeakUnity via Method.invoke

### DIFF
--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,6 +1,7 @@
 bug:
   - "Fixed a crash (NPE) when claiming a reward if the server response was empty or had an unexpected shape. `TeakNotification.Reward.rewardFromRewardId` now resolves to a reward with `UNKNOWN` status instead of crashing or hanging."
   - "Fixed `JSONException` Sentry noise from malformed server responses (HTML error pages, proxy errors) in request callbacks. Non-JSON bodies now fall back to `{}` and log a breadcrumb instead of hitting Sentry."
+  - "Fixed `UnsatisfiedLinkError` from `UnitySendMessage` being incorrectly reported to Sentry. `Method.invoke` wraps errors in `InvocationTargetException`; the catch block now correctly suppresses the wrapped form."
 
 enhancement:
   - "Sentry exception reports now include breadcrumbs from recent `Teak.log` events, making crashes easier to diagnose."

--- a/src/main/java/io/teak/sdk/wrapper/unity/TeakUnity.java
+++ b/src/main/java/io/teak/sdk/wrapper/unity/TeakUnity.java
@@ -1,5 +1,6 @@
 package io.teak.sdk.wrapper.unity;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -69,16 +70,27 @@ public class TeakUnity implements Unobfuscable {
         return TeakUnity.unitySendMessage != null;
     }
 
+    static boolean shouldSuppressException(Throwable e) {
+        if (e instanceof UnsatisfiedLinkError) return true;
+        if (e instanceof InvocationTargetException && e.getCause() instanceof UnsatisfiedLinkError) return true;
+        return false;
+    }
+
     private static void unitySendMessage(final String method, final String message) {
         TeakUnity.unitySendMessageExecutor.submit(() -> {
             if (TeakUnity.isAvailable()) {
                 try {
                     TeakUnity.unitySendMessage.invoke(null, "TeakGameObject", method, message);
                 } catch (UnsatisfiedLinkError ignored) {
+                    // defensive: ULE normally arrives wrapped via InvocationTargetException, see below
+                } catch (InvocationTargetException e) {
                     // TEAK-ANDROID-SDK-K4
                     // TEAK-ANDROID-SDK-K5
                     // TEAK-ANDROID-SDK-K6
                     // TEAK-ANDROID-SDK-K9
+                    if (!shouldSuppressException(e)) {
+                        Teak.log.exception(e);
+                    }
                 } catch (Exception e) {
                     Teak.log.exception(e);
                 }

--- a/test_app/app/src/test/java/io/teak/sdk/wrapper/unity/TeakUnityUleTest.java
+++ b/test_app/app/src/test/java/io/teak/sdk/wrapper/unity/TeakUnityUleTest.java
@@ -1,0 +1,33 @@
+package io.teak.sdk.wrapper.unity;
+
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TeakUnityUleTest {
+
+    @Test
+    public void ule_direct_isSuppressed() {
+        assertTrue(TeakUnity.shouldSuppressException(new UnsatisfiedLinkError()));
+    }
+
+    @Test
+    public void invocationTargetException_wrappingUle_isSuppressed() {
+        assertTrue(TeakUnity.shouldSuppressException(
+            new InvocationTargetException(new UnsatisfiedLinkError())));
+    }
+
+    @Test
+    public void invocationTargetException_wrappingOtherCause_isNotSuppressed() {
+        assertFalse(TeakUnity.shouldSuppressException(
+            new InvocationTargetException(new RuntimeException("other error"))));
+    }
+
+    @Test
+    public void genericException_isNotSuppressed() {
+        assertFalse(TeakUnity.shouldSuppressException(new RuntimeException("something broke")));
+    }
+}


### PR DESCRIPTION
https://linear.app/teakio/issue/C-737

`Method.invoke` wraps any thrown `Error` in `InvocationTargetException`, so the direct `catch (UnsatisfiedLinkError)` in `unitySendMessage` was dead code. The ULE was arriving as an `InvocationTargetException`, falling through to `catch (Exception e)` and hitting Sentry (TEAK-ANDROID-SDK-2FQ).

**Fix:** extract a `shouldSuppressException(Throwable)` predicate (true for a direct ULE or an `InvocationTargetException` whose cause is a ULE), add a `catch (InvocationTargetException)` block that uses it, and move the K4/K5/K6/K9 Sentry refs there — which is where suppression actually happens. The direct ULE catch is kept as thin defensive cover with a corrected comment.

**Tests:** `TeakUnityUleTest` covers all four arms of the predicate (direct suppressed, wrapped suppressed, wrapped other cause, unrelated exception), mirroring the `TransientFcmErrorTest` pattern.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)