### PR TITLE
Guard willProcessUri against malformed deep link URIs (C-735)

### DIFF
--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -2,6 +2,7 @@ bug:
   - "Fixed a crash (NPE) when claiming a reward if the server response was empty or had an unexpected shape. `TeakNotification.Reward.rewardFromRewardId` now resolves to a reward with `UNKNOWN` status instead of crashing or hanging."
   - "Fixed `JSONException` Sentry noise from malformed server responses (HTML error pages, proxy errors) in request callbacks. Non-JSON bodies now fall back to `{}` and log a breadcrumb instead of hitting Sentry."
   - "Reward links that resolve without an `AndroidPath` now retain the originating launch link for attribution instead of dropping it, matching the iOS resolver."
+  - "Fixed an `IllegalArgumentException` (\"Malformed escape pair\") when a deep link contained an unencoded `%` (e.g. a `50%` creative or schedule name). `DeepLink.willProcessUri` now guards `URI.create` the same way `processUri` already did, so such links no longer throw."
 
 enhancement:
   - "Sentry exception reports now include breadcrumbs from recent `Teak.log` events, making crashes easier to diagnose."

--- a/src/main/java/io/teak/sdk/core/DeepLink.java
+++ b/src/main/java/io/teak/sdk/core/DeepLink.java
@@ -84,7 +84,15 @@ public class DeepLink implements Unobfuscable {
 
 public static boolean willProcessUri(Uri uri) {
     if (uri == null) return false;
-    return DeepLink.willProcessUri(URI.create(uri.toString()));
+
+    URI otherUri = null;
+    try {
+        otherUri = URI.create(uri.toString());
+    } catch (Exception ignored) {
+        return false;
+    }
+
+    return DeepLink.willProcessUri(otherUri);
 }
 
 public static boolean willProcessUri(URI uri) {

--- a/test_app/app/src/test/java/io/teak/app/test/DeepLinkRoutes.java
+++ b/test_app/app/src/test/java/io/teak/app/test/DeepLinkRoutes.java
@@ -1,5 +1,7 @@
 package io.teak.app.test;
 
+import android.net.Uri;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -14,10 +16,12 @@ import io.teak.sdk.Teak;
 import io.teak.sdk.core.DeepLink;
 
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeepLinkRoutes extends TeakUnitTest {
@@ -137,6 +141,16 @@ public class DeepLinkRoutes extends TeakUnitTest {
         arg.put(DeepLink.INCOMING_URL_PATH_KEY, uri.getPath());
         arg.put(DeepLink.INCOMING_URL_KEY, uri.toString());
         verify(callback, timeout(100)).call(arg);
+    }
+
+    // A bare '%' (e.g. an unencoded "50%" creative name) makes URI.create throw
+    // "Malformed escape pair". willProcessUri must swallow that and return false,
+    // matching processUri, rather than letting it propagate. C-735.
+    @Test
+    public void willProcessUriWithUnencodedPercentDoesNotThrow() {
+        final Uri uri = mock(Uri.class);
+        when(uri.toString()).thenReturn("teak" + TestAppId + ":///deep_link?teak_creative_name=50%+Off");
+        assertFalse(DeepLink.willProcessUri(uri));
     }
 
     /**


### PR DESCRIPTION
[sdks-teak-android-worker-c-735]

Linear: https://linear.app/teakio/issue/C-735

## What

`DeepLink.willProcessUri(Uri)` called `URI.create(uri.toString())` with no exception handling. When a deep link's creative or schedule name contains an unencoded `%` (e.g. a `50%` name), the bare `%` makes `URI.create` throw `IllegalArgumentException: Malformed escape pair`. The sibling `processUri(Uri)` already guards that call with try/catch returning false — `willProcessUri` just never got the same guard.

This mirrors that guard, adds a regression test, and a changelog entry. Sentry: TEAK-ANDROID-SDK-2EP / 2EQ (22 users, 126 events since February).

## Behavior

A bare-% URI now returns `false` from `willProcessUri` instead of throwing. Both callers degrade gracefully:
- `Session.checkLaunchDataForDeepLinkAndPostEvents` falls through to the external-intent (`ACTION_VIEW`) path.
- `AttributedLaunchData.toMap` returns a null `teakDeepLink`.

## Why guard, not salvage

The alternative would be to *normalize* the bare `%` (encode it to `%25`) before `URI.create` so the link still routes. We deliberately did not:
- Re-encoding risks double-encoding already-valid escapes (`%20` → `%2520`), corrupting links that are correct today.
- A URL we can't parse shouldn't be routed as if we understood it — returning false is the same contract `processUri` already follows, so the two stay consistent.

Dropping an unparseable link silently (no route) is the correct, conservative behavior for a point release.

## Root cause (investigation deliverable)

The bare `%` originates **server-side** when email-channel links are constructed from a creative/schedule name containing a literal `%`. The affected URLs consistently come from email links with `+`-encoded spaces and a literal `%` in the name — the name isn't percent-encoded (`%` → `%25`) before being embedded in the link.

This SDK guard stops the crash, but the real fix is upstream: the server should percent-encode `%` as `%25` when building these links. Flagging for a server-repo followup.

## Testing

`(cd test_app && ANDROID_HOME=$HOME/Library/Android/sdk ./gradlew testDebugUnitTest --tests "io.teak.app.test.DeepLinkRoutes")` — all pass, including the new `willProcessUriWithUnencodedPercentDoesNotThrow`.
