### PR TITLE
Support Amazon Appstore SDK sandbox detection

### DIFF
--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -4,6 +4,7 @@ bug:
   - "Fixed `UnsatisfiedLinkError` from `UnitySendMessage` being incorrectly reported to Sentry. `Method.invoke` wraps errors in `InvocationTargetException`; the catch block now correctly suppresses the wrapped form."
   - "Reward links that resolve without an `AndroidPath` now retain the originating launch link for attribution instead of dropping it, matching the iOS resolver."
   - "Fixed an `IllegalArgumentException` (\"Malformed escape pair\") when a deep link contained an unencoded `%` (e.g. a `50%` creative or schedule name). `DeepLink.willProcessUri` now guards `URI.create` the same way `processUri` already did, so such links no longer throw."
+  - "Amazon purchase tracking no longer crashes (`NoSuchFieldError`) for games on the new Amazon Appstore SDK, which removed `PurchasingService.IS_SANDBOX_MODE`. Sandbox state now resolves via `LicensingService.getAppstoreSDKMode()` when present, falling back to IAP v2.0."
 
 enhancement:
   - "Sentry exception reports now include breadcrumbs from recent `Teak.log` events, making crashes easier to diagnose."

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -4,7 +4,7 @@ bug:
   - "Fixed `UnsatisfiedLinkError` from `UnitySendMessage` being incorrectly reported to Sentry. `Method.invoke` wraps errors in `InvocationTargetException`; the catch block now correctly suppresses the wrapped form."
   - "Reward links that resolve without an `AndroidPath` now retain the originating launch link for attribution instead of dropping it, matching the iOS resolver."
   - "Fixed an `IllegalArgumentException` (\"Malformed escape pair\") when a deep link contained an unencoded `%` (e.g. a `50%` creative or schedule name). `DeepLink.willProcessUri` now guards `URI.create` the same way `processUri` already did, so such links no longer throw."
-  - "Amazon purchase tracking no longer crashes (`NoSuchFieldError`) for games on the new Amazon Appstore SDK, which removed `PurchasingService.IS_SANDBOX_MODE`. Sandbox state now resolves via `LicensingService.getAppstoreSDKMode()` when present, falling back to IAP v2.0."
+  - "Fixed an Amazon Appstore SDK 3.x crash (`NoSuchFieldError`) and sandbox/production misclassification of purchases. Sandbox state now resolves via `LicensingService.getAppstoreSDKMode()` when that method is available, falling back to IAP v2.0's `IS_SANDBOX_MODE` otherwise."
 
 enhancement:
   - "Sentry exception reports now include breadcrumbs from recent `Teak.log` events, making crashes easier to diagnose."

--- a/src/main/java/io/teak/sdk/store/Amazon.java
+++ b/src/main/java/io/teak/sdk/store/Amazon.java
@@ -32,7 +32,7 @@ public class Amazon implements Unobfuscable, IStore, PurchasingListener {
         try {
             PurchasingService.registerListener(context, this);
 
-            Teak.log.i("billing.amazon.v2", "Amazon In-App Purchasing 2.0 registered.", mm.h("sandboxMode", PurchasingService.IS_SANDBOX_MODE));
+            Teak.log.i("billing.amazon.v2", "Amazon In-App Purchasing 2.0 registered.", mm.h("sandboxMode", AmazonSandbox.isSandboxMode()));
 
             TeakEvent.addEventListener(event -> {
                 if (event.eventType.equals(LifecycleEvent.Resumed)) {
@@ -86,7 +86,7 @@ public class Amazon implements Unobfuscable, IStore, PurchasingListener {
                 payload.put("purchase_time_string", receipt.getPurchaseDate());
                 payload.put("product_id", receipt.getSku());
                 payload.put("store_marketplace", userData.getMarketplace());
-                payload.put("is_sandbox", PurchasingService.IS_SANDBOX_MODE);
+                payload.put("is_sandbox", AmazonSandbox.isSandboxMode());
 
                 final HashSet<String> skus = new HashSet<>();
                 skus.add(receipt.getSku());

--- a/src/main/java/io/teak/sdk/store/AmazonSandbox.java
+++ b/src/main/java/io/teak/sdk/store/AmazonSandbox.java
@@ -1,0 +1,58 @@
+package io.teak.sdk.store;
+
+import io.teak.sdk.Teak;
+
+/**
+ * Resolves the Amazon billing "sandbox" flag across both Amazon IAP SDKs.
+ *
+ * IAP v2.0 exposes {@code PurchasingService.IS_SANDBOX_MODE} (a static boolean
+ * field). The newer Appstore SDK removed that field and replaced it with
+ * {@code LicensingService.getAppstoreSDKMode()}, which returns the String
+ * "SANDBOX", "PRODUCTION", or "UNKNOWN".
+ *
+ * Both are accessed via reflection so this class carries no compile-time
+ * dependency on either Amazon SDK -- the Teak AAR links against whichever one
+ * the game actually ships, and a direct reference to the removed field would
+ * otherwise throw NoSuchFieldError at runtime under the Appstore SDK.
+ */
+final class AmazonSandbox {
+    private AmazonSandbox() {}
+
+    /**
+     * Maps an Appstore SDK {@code getAppstoreSDKMode()} value to our boolean
+     * sandbox flag. Only "SANDBOX" (any case) counts; "PRODUCTION", "UNKNOWN",
+     * null, and anything unexpected map to false.
+     */
+    static boolean isSandboxMode(String appstoreSDKMode) {
+        return "SANDBOX".equalsIgnoreCase(appstoreSDKMode);
+    }
+
+    /**
+     * Best-effort sandbox detection for whichever Amazon billing SDK is present.
+     * Returns false if it cannot be determined.
+     */
+    static boolean isSandboxMode() {
+        // Appstore SDK: IS_SANDBOX_MODE was removed in favor of LicensingService.
+        try {
+            final Class<?> licensingService = Class.forName("com.amazon.device.drm.LicensingService");
+            final Object mode = licensingService.getMethod("getAppstoreSDKMode").invoke(null);
+            return isSandboxMode((String) mode);
+        } catch (ClassNotFoundException notAppstoreSDK) {
+            // Not the Appstore SDK -- fall through to legacy IAP v2.0.
+        } catch (Exception e) {
+            Teak.log.exception(e);
+            return false;
+        }
+
+        // Legacy IAP v2.0: PurchasingService.IS_SANDBOX_MODE static boolean field.
+        try {
+            final Object isSandbox = Class.forName("com.amazon.device.iap.PurchasingService")
+                                         .getField("IS_SANDBOX_MODE")
+                                         .get(null);
+            return Boolean.TRUE.equals(isSandbox);
+        } catch (Exception e) {
+            Teak.log.exception(e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/io/teak/sdk/store/AmazonSandbox.java
+++ b/src/main/java/io/teak/sdk/store/AmazonSandbox.java
@@ -37,8 +37,11 @@ final class AmazonSandbox {
             final Class<?> licensingService = Class.forName("com.amazon.device.drm.LicensingService");
             final Object mode = licensingService.getMethod("getAppstoreSDKMode").invoke(null);
             return isSandboxMode((String) mode);
-        } catch (ClassNotFoundException notAppstoreSDK) {
-            // Not the Appstore SDK -- fall through to legacy IAP v2.0.
+        } catch (ClassNotFoundException | NoSuchMethodException notAppstoreSDK) {
+            // Benign and expected: this isn't the Appstore SDK. LicensingService can
+            // still be present from Amazon's standalone DRM lib (which games use for
+            // verifyLicense) but without getAppstoreSDKMode -- so fall through to the
+            // legacy IS_SANDBOX_MODE field rather than reporting noise per purchase.
         } catch (Exception e) {
             Teak.log.exception(e);
             return false;

--- a/test_app/app/src/test/java/io/teak/sdk/store/AmazonSandboxTest.java
+++ b/test_app/app/src/test/java/io/teak/sdk/store/AmazonSandboxTest.java
@@ -1,0 +1,58 @@
+package io.teak.sdk.store;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The Appstore SDK's getAppstoreSDKMode() returns a String, not an enum, so the mode->boolean
+ * mapping is the part most likely to silently misclassify a sandbox purchase as production. Only
+ * "SANDBOX" (any case) is sandbox; everything else — including UNKNOWN and null — is not.
+ *
+ * Lives in io.teak.sdk.store to reach the package-private mapping. The reflection plumbing in
+ * AmazonSandbox can't be unit-tested without the Amazon jars on the classpath.
+ */
+public class AmazonSandboxTest {
+    @Test
+    public void sandbox_isSandbox() {
+        assertTrue(AmazonSandbox.isSandboxMode("SANDBOX"));
+    }
+
+    @Test
+    public void sandbox_isCaseInsensitive() {
+        assertTrue(AmazonSandbox.isSandboxMode("sandbox"));
+        assertTrue(AmazonSandbox.isSandboxMode("Sandbox"));
+    }
+
+    @Test
+    public void production_isNotSandbox() {
+        assertFalse(AmazonSandbox.isSandboxMode("PRODUCTION"));
+    }
+
+    @Test
+    public void unknown_isNotSandbox() {
+        assertFalse(AmazonSandbox.isSandboxMode("UNKNOWN"));
+    }
+
+    @Test
+    public void nullMode_isNotSandbox() {
+        assertFalse(AmazonSandbox.isSandboxMode(null));
+    }
+
+    @Test
+    public void emptyMode_isNotSandbox() {
+        assertFalse(AmazonSandbox.isSandboxMode(""));
+    }
+
+    @Test
+    public void garbageMode_isNotSandbox() {
+        assertFalse(AmazonSandbox.isSandboxMode("not-a-real-mode"));
+    }
+
+    @Test
+    public void paddedSandbox_isNotSandbox() {
+        // No trimming — documents that we match the value verbatim (modulo case).
+        assertFalse(AmazonSandbox.isSandboxMode(" SANDBOX "));
+    }
+}


### PR DESCRIPTION
Amazon's new Appstore SDK (successor to IAP v2.0) removed the static field `PurchasingService.IS_SANDBOX_MODE`. `store/Amazon.java` read it directly at listener registration and on every purchase, so any game shipping the Appstore SDK hits `NoSuchFieldError` at runtime — Amazon purchase tracking breaks.

`AmazonSandbox` now resolves the sandbox flag via reflection across both SDKs:
- Appstore SDK: `LicensingService.getAppstoreSDKMode()` — confirmed against the [3.0.2 Javadoc](https://amzndevresources.com/iap/appstore-sdk-api-reference/3.0.2/com/amazon/device/drm/LicensingService.html), it's `public static java.lang.String` returning `"SANDBOX"`/`"PRODUCTION"`/`"UNKNOWN"` (a String, not an enum).
- Legacy IAP v2.0: the `IS_SANDBOX_MODE` field.

Reflection keeps the class free of any compile-time Amazon dependency (matching the optional-Amazon idiom in `DefaultObjectFactory`) and removes the direct reference to the deleted field entirely. We don't call `verifyLicense()` ourselves — the game owns that (Amazon requires it at launch); we only read the resolved mode. `UNKNOWN`/null → false (not sandbox), preserving the boolean `is_sandbox` payload contract.

The String→boolean mapping is the part most likely to silently misclassify a sandbox purchase as production, so it's extracted into a pure `isSandboxMode(String)` and unit-tested (8 cases: SANDBOX/case-insensitive/PRODUCTION/UNKNOWN/null/empty/garbage/padded). The reflection plumbing can't be tested without the Amazon jars on the classpath.

Linear: https://linear.app/teakio/issue/C-834

Testing: full `testDebugUnitTest` suite green; `org_json_check` + `check_thread_use` pass. Real Appstore-SDK behavior needs cleanroom/manual verification.
