### PR TITLE
Bound Sentry exception report payload by serialized size (C-863)

### DIFF
--- a/src/main/java/io/teak/sdk/raven/Raven.java
+++ b/src/main/java/io/teak/sdk/raven/Raven.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -358,32 +359,41 @@ public class Raven implements Thread.UncaughtExceptionHandler {
     }
 
     // Returns the breadcrumbs (in chronological order) that fit within budgetBytes when attached
-    // to basePayload, keeping the NEWEST crumbs. basePayload must not already contain breadcrumbs.
-    // If basePayload alone is already over budget, returns an empty list (the core report still
+    // to basePayload, keeping the NEWEST crumbs. Sizing is exact and O(n): `withEmpty` -- the
+    // payload carrying an empty breadcrumbs wrapper -- is serialized once and captures the
+    // `,"breadcrumbs":{"values":[]}` attach overhead without hardcoding it. A crumb serializes
+    // byte-identically standalone as it does inside the "values" array, so the assembled size of
+    // k crumbs is exactly withEmpty + sum(crumb sizes) + (k-1) inter-crumb commas. Keep the newest
+    // crumbs whose running total stays within budget, then reverse once into Sentry's chronological
+    // order. If basePayload alone is already over budget, returns empty (the core report still
     // sends). Static + public so it can be unit-tested without an Android runtime.
     public static List<Map<String, Object>> fitBreadcrumbsToBudget(@NonNull Map<String, Object> basePayload,
         @NonNull List<Map<String, Object>> snapshot, int budgetBytes) {
-        final ArrayDeque<Map<String, Object>> kept = new ArrayDeque<>();
+        final List<Map<String, Object>> kept = new ArrayList<>();
         if (snapshot.isEmpty() || jsonByteLength(basePayload) > budgetBytes) {
-            return new ArrayList<>(kept);
+            return kept;
         }
 
-        // trial = basePayload + a growing breadcrumbs set; re-measured as each crumb is added.
-        final HashMap<String, Object> trial = new HashMap<>(basePayload);
-        final HashMap<String, Object> breadcrumbsPayload = new HashMap<>();
-        trial.put("breadcrumbs", breadcrumbsPayload);
+        // Baseline = the payload with an empty breadcrumbs wrapper, serialized once. The first
+        // crumb's size adds directly onto this; each subsequent crumb also costs one comma byte.
+        final HashMap<String, Object> withEmpty = new HashMap<>(basePayload);
+        final HashMap<String, Object> wrapper = new HashMap<>();
+        wrapper.put("values", new ArrayList<>());
+        withEmpty.put("breadcrumbs", wrapper);
+        int used = jsonByteLength(withEmpty);
 
-        // Walk newest-first; addFirst keeps `kept` in chronological (oldest-first) order, which is
-        // what Sentry expects in the "values" array.
+        // Walk newest-first, accumulating exact serialized size, until the next crumb would exceed
+        // the budget. Reversed below so `kept` ends up oldest-first.
         for (int i = snapshot.size() - 1; i >= 0; i--) {
-            kept.addFirst(snapshot.get(i));
-            breadcrumbsPayload.put("values", new ArrayList<>(kept));
-            if (jsonByteLength(trial) > budgetBytes) {
-                kept.removeFirst();
+            final int crumbBytes = jsonByteLength(snapshot.get(i)) + (kept.isEmpty() ? 0 : 1);
+            if (used + crumbBytes > budgetBytes) {
                 break;
             }
+            used += crumbBytes;
+            kept.add(snapshot.get(i));
         }
-        return new ArrayList<>(kept);
+        Collections.reverse(kept);
+        return kept;
     }
 
     private static int jsonByteLength(@NonNull Map<String, Object> map) {
@@ -483,14 +493,18 @@ public class Raven implements Thread.UncaughtExceptionHandler {
                 this.payload.put("breadcrumbs", breadcrumbsPayload);
             }
 
+            // Serialize the final payload exactly once; the same String feeds both the size log
+            // below and the Data value in buildData().
+            final String payloadJson = new JSONObject(this.payload).toString();
+
             // Observability: how many breadcrumbs survived size-budgeting and the resulting
             // payload size. Fires once per exception report (rare); trimming is normal operation,
             // hence debug, not warn/error.
             Log.d(LOG_TAG, "Sentry report: " + fitted.size() + " of " + this.breadcrumbSnapshot.size()
-                               + " breadcrumbs kept, payload " + Raven.jsonByteLength(this.payload)
+                               + " breadcrumbs kept, payload " + payloadJson.getBytes(StandardCharsets.UTF_8).length
                                + " bytes (size budget " + PAYLOAD_BUDGET_BYTES + ").");
 
-            Data data = this.buildData();
+            Data data = this.buildData(payloadJson);
             if (data != null) {
                 return data;
             }
@@ -498,21 +512,22 @@ public class Raven implements Thread.UncaughtExceptionHandler {
             // Backstop: the payload still exceeds WorkManager's Data cap after size-budgeting
             // breadcrumbs. Don't silently drop the report — log loudly and retry with the core
             // exception only (matching pre-breadcrumbs 4.3.12 behavior). This should essentially
-            // never fire given the conservative budget above.
+            // never fire given the conservative budget above, and is the only path that serializes
+            // a second time.
             Log.e(LOG_TAG, "Sentry report exceeded WorkManager Data cap; retrying without breadcrumbs.");
             this.payload.remove("breadcrumbs");
-            data = this.buildData();
+            data = this.buildData(new JSONObject(this.payload).toString());
             if (data == null) {
                 Log.e(LOG_TAG, "Sentry report exceeds WorkManager Data cap even without breadcrumbs; dropping.");
             }
             return data;
         }
 
-        private Data buildData() {
+        private Data buildData(String payloadJson) {
             try {
                 return new Data.Builder()
                     .putLong(Sender.TIMESTAMP_KEY, this.timestamp.getTime() / 1000L)
-                    .putString(Sender.PAYLOAD_KEY, new JSONObject(this.payload).toString())
+                    .putString(Sender.PAYLOAD_KEY, payloadJson)
                     .putString(Sender.ENDPOINT_KEY, Raven.this.endpoint.toString())
                     .putString(Sender.SENTRY_KEY_KEY, Raven.this.SENTRY_KEY)
                     .putString(Sender.SENTRY_SECRET_KEY, Raven.this.SENTRY_SECRET)

--- a/src/main/java/io/teak/sdk/raven/Raven.java
+++ b/src/main/java/io/teak/sdk/raven/Raven.java
@@ -7,6 +7,7 @@ import android.util.Log;
 
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -63,8 +64,18 @@ public class Raven implements Thread.UncaughtExceptionHandler {
         }
     }
 
+    // Upper bound on breadcrumbs retained in memory (bounds history growth between reports).
+    // The number actually attached to a report is governed by PAYLOAD_BUDGET_BYTES, not this.
     private static final int BREADCRUMB_LIMIT = 100;
     private final ArrayDeque<Map<String, Object>> breadcrumbs = new ArrayDeque<>();
+
+    // Max serialized JSON bytes of the report payload (including breadcrumbs) we allow before
+    // it is handed to a WorkManager Data value. WorkManager caps a Data blob at 10240 bytes
+    // total (Data.MAX_DATA_BYTES) and build() throws past it. We budget the JSON conservatively,
+    // leaving headroom for the endpoint/key/timestamp entries and WorkManager's own marshalling
+    // overhead, which also count toward the cap. Breadcrumbs are trimmed newest-first to fit; the
+    // breadcrumb-free core report always sends.
+    private static final int PAYLOAD_BUDGET_BYTES = 8 * 1024;
 
     private final List<Report> queuedReports = new ArrayList<>();
     private final HashMap<String, Object> payloadTemplate = new HashMap<>();
@@ -346,6 +357,39 @@ public class Raven implements Thread.UncaughtExceptionHandler {
         }
     }
 
+    // Returns the breadcrumbs (in chronological order) that fit within budgetBytes when attached
+    // to basePayload, keeping the NEWEST crumbs. basePayload must not already contain breadcrumbs.
+    // If basePayload alone is already over budget, returns an empty list (the core report still
+    // sends). Static + public so it can be unit-tested without an Android runtime.
+    public static List<Map<String, Object>> fitBreadcrumbsToBudget(@NonNull Map<String, Object> basePayload,
+        @NonNull List<Map<String, Object>> snapshot, int budgetBytes) {
+        final ArrayDeque<Map<String, Object>> kept = new ArrayDeque<>();
+        if (snapshot.isEmpty() || jsonByteLength(basePayload) > budgetBytes) {
+            return new ArrayList<>(kept);
+        }
+
+        // trial = basePayload + a growing breadcrumbs set; re-measured as each crumb is added.
+        final HashMap<String, Object> trial = new HashMap<>(basePayload);
+        final HashMap<String, Object> breadcrumbsPayload = new HashMap<>();
+        trial.put("breadcrumbs", breadcrumbsPayload);
+
+        // Walk newest-first; addFirst keeps `kept` in chronological (oldest-first) order, which is
+        // what Sentry expects in the "values" array.
+        for (int i = snapshot.size() - 1; i >= 0; i--) {
+            kept.addFirst(snapshot.get(i));
+            breadcrumbsPayload.put("values", new ArrayList<>(kept));
+            if (jsonByteLength(trial) > budgetBytes) {
+                kept.removeFirst();
+                break;
+            }
+        }
+        return new ArrayList<>(kept);
+    }
+
+    private static int jsonByteLength(@NonNull Map<String, Object> map) {
+        return new JSONObject(map).toString().getBytes(StandardCharsets.UTF_8).length;
+    }
+
     private Map<String, Object> toMap() {
         HashMap<String, Object> ret = new HashMap<>();
         ret.put("appId", this.appId);
@@ -366,6 +410,7 @@ public class Raven implements Thread.UncaughtExceptionHandler {
 
     private class Report {
         final HashMap<String, Object> payload = new HashMap<>();
+        final List<Map<String, Object>> breadcrumbSnapshot;
         final Date timestamp = new Date();
         final String uuid = UUID.randomUUID().toString().replace("-", "");
 
@@ -402,20 +447,22 @@ public class Raven implements Thread.UncaughtExceptionHandler {
                 payload.putAll(additions);
             }
 
-            final List<Map<String, Object>> breadcrumbSnapshot = Raven.this.snapshotBreadcrumbs();
-            if (!breadcrumbSnapshot.isEmpty()) {
-                final HashMap<String, Object> breadcrumbsPayload = new HashMap<>();
-                breadcrumbsPayload.put("values", breadcrumbSnapshot);
-                payload.put("breadcrumbs", breadcrumbsPayload);
-            }
+            // Snapshot breadcrumbs as-of-now (i.e. as-of-exception). They are fitted to the size
+            // budget and attached at toData() time, when the full Data envelope is known.
+            this.breadcrumbSnapshot = Raven.this.snapshotBreadcrumbs();
         }
 
         void send() {
+            final Data data = this.toData();
+            if (data == null) {
+                // toData() already logged loudly; don't enqueue a null-Data request.
+                return;
+            }
             final Constraints constraints = new Constraints.Builder()
                                                 .setRequiredNetworkType(NetworkType.CONNECTED)
                                                 .build();
             final OneTimeWorkRequest request = new OneTimeWorkRequest.Builder(Sender.class)
-                                                   .setInputData(this.toData())
+                                                   .setInputData(data)
                                                    .setConstraints(constraints)
                                                    .build();
             WorkManager.getInstance(Raven.this.applicationContext)
@@ -424,19 +471,56 @@ public class Raven implements Thread.UncaughtExceptionHandler {
 
         Data toData() {
             this.payload.putAll(Raven.this.payloadTemplate);
-            try {
-                Data.Builder data = new Data.Builder()
-                                        .putLong(Sender.TIMESTAMP_KEY, this.timestamp.getTime() / 1000L)
-                                        .putString(Sender.PAYLOAD_KEY, new JSONObject(this.payload).toString())
-                                        .putString(Sender.ENDPOINT_KEY, Raven.this.endpoint.toString())
-                                        .putString(Sender.SENTRY_KEY_KEY, Raven.this.SENTRY_KEY)
-                                        .putString(Sender.SENTRY_SECRET_KEY, Raven.this.SENTRY_SECRET);
-                return data.build();
-            } catch (Exception e) {
-                Log.e(LOG_TAG, Log.getStackTraceString(e));
+
+            // Attach as many breadcrumbs as fit within the size budget, newest-first. The core
+            // breadcrumb-free payload is what's measured against; if it's already over budget no
+            // breadcrumbs are added and it still sends.
+            final List<Map<String, Object>> fitted =
+                Raven.fitBreadcrumbsToBudget(this.payload, this.breadcrumbSnapshot, PAYLOAD_BUDGET_BYTES);
+            if (!fitted.isEmpty()) {
+                final HashMap<String, Object> breadcrumbsPayload = new HashMap<>();
+                breadcrumbsPayload.put("values", fitted);
+                this.payload.put("breadcrumbs", breadcrumbsPayload);
             }
 
-            return null;
+            // Observability: how many breadcrumbs survived size-budgeting and the resulting
+            // payload size. Fires once per exception report (rare); trimming is normal operation,
+            // hence debug, not warn/error.
+            Log.d(LOG_TAG, "Sentry report: " + fitted.size() + " of " + this.breadcrumbSnapshot.size()
+                               + " breadcrumbs kept, payload " + Raven.jsonByteLength(this.payload)
+                               + " bytes (size budget " + PAYLOAD_BUDGET_BYTES + ").");
+
+            Data data = this.buildData();
+            if (data != null) {
+                return data;
+            }
+
+            // Backstop: the payload still exceeds WorkManager's Data cap after size-budgeting
+            // breadcrumbs. Don't silently drop the report — log loudly and retry with the core
+            // exception only (matching pre-breadcrumbs 4.3.12 behavior). This should essentially
+            // never fire given the conservative budget above.
+            Log.e(LOG_TAG, "Sentry report exceeded WorkManager Data cap; retrying without breadcrumbs.");
+            this.payload.remove("breadcrumbs");
+            data = this.buildData();
+            if (data == null) {
+                Log.e(LOG_TAG, "Sentry report exceeds WorkManager Data cap even without breadcrumbs; dropping.");
+            }
+            return data;
+        }
+
+        private Data buildData() {
+            try {
+                return new Data.Builder()
+                    .putLong(Sender.TIMESTAMP_KEY, this.timestamp.getTime() / 1000L)
+                    .putString(Sender.PAYLOAD_KEY, new JSONObject(this.payload).toString())
+                    .putString(Sender.ENDPOINT_KEY, Raven.this.endpoint.toString())
+                    .putString(Sender.SENTRY_KEY_KEY, Raven.this.SENTRY_KEY)
+                    .putString(Sender.SENTRY_SECRET_KEY, Raven.this.SENTRY_SECRET)
+                    .build();
+            } catch (Exception e) {
+                Log.e(LOG_TAG, Log.getStackTraceString(e));
+                return null;
+            }
         }
 
         Map<String, Object> toMap() {

--- a/src/main/java/io/teak/sdk/raven/Raven.java
+++ b/src/main/java/io/teak/sdk/raven/Raven.java
@@ -359,7 +359,10 @@ public class Raven implements Thread.UncaughtExceptionHandler {
     }
 
     // Returns the breadcrumbs (in chronological order) that fit within budgetBytes when attached
-    // to basePayload, keeping the NEWEST crumbs. Sizing is exact and O(n): `withEmpty` -- the
+    // to basePayload, keeping the NEWEST crumbs. PRECONDITION: basePayload carries no `breadcrumbs`
+    // key -- the caller owns attaching the fitted set; withEmpty and toData's final attach both
+    // put() that key, so a pre-existing one would be silently replaced (not double-counted -- the
+    // measurement stays self-consistent either way). Sizing is exact and O(n): `withEmpty` -- the
     // payload carrying an empty breadcrumbs wrapper -- is serialized once and captures the
     // `,"breadcrumbs":{"values":[]}` attach overhead without hardcoding it. A crumb serializes
     // byte-identically standalone as it does inside the "values" array, so the assembled size of

--- a/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
@@ -123,6 +123,14 @@ public class RavenBreadcrumbTest extends TeakUnitTest {
         for (int j = 0; j < fitted.size(); j++) {
             assertEquals(first + j, crumbIndex(fitted.get(j)));
         }
+
+        // Maximality: the next-older crumb that was dropped would have pushed the real serialized
+        // size over budget. The <=budget assert above catches under-keeping; this catches
+        // over-keeping (a comma/wrapper off-by-one in the size algebra leaving room it shouldn't).
+        final List<Map<String, Object>> oneMore = new ArrayList<>();
+        oneMore.add(crumb(first - 1));
+        oneMore.addAll(fitted);
+        assertTrue("dropping a crumb that would have fit", serializedSize(base, oneMore) > budget);
     }
 
     // Under budget: keep everything, in chronological order.

--- a/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
@@ -5,11 +5,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import io.teak.sdk.Teak;
 import io.teak.sdk.TeakConfiguration;
+import io.teak.sdk.json.JSONObject;
 import io.teak.sdk.raven.Raven;
 
 import static org.junit.Assert.assertEquals;
@@ -71,5 +75,90 @@ public class RavenBreadcrumbTest extends TeakUnitTest {
         for (Map<String, Object> crumb : breadcrumbs) {
             assertFalse("exception".equals(crumb.get("message")));
         }
+    }
+
+    private static Map<String, Object> crumb(int i) {
+        final HashMap<String, Object> c = new HashMap<>();
+        c.put("timestamp", "2026-06-22T00:00:00");
+        c.put("level", "info");
+        c.put("category", "event." + i);
+        c.put("message", "event." + i);
+        return c;
+    }
+
+    private static int serializedSize(Map<String, Object> base, List<Map<String, Object>> crumbs) {
+        final HashMap<String, Object> trial = new HashMap<>(base);
+        final HashMap<String, Object> breadcrumbs = new HashMap<>();
+        breadcrumbs.put("values", crumbs);
+        trial.put("breadcrumbs", breadcrumbs);
+        return new JSONObject(trial).toString().getBytes(StandardCharsets.UTF_8).length;
+    }
+
+    private static int crumbIndex(Map<String, Object> crumb) {
+        return Integer.parseInt(((String) crumb.get("message")).substring("event.".length()));
+    }
+
+    // Over budget: keep a non-empty set of the NEWEST crumbs, in chronological order, under budget.
+    // This is the C-863 acceptance case — a bounded, non-empty breadcrumb set still ships.
+    @Test
+    public void budgetTrimsToNewestWithinBudget() {
+        final HashMap<String, Object> base = new HashMap<>();
+        base.put("level", "error");
+
+        final List<Map<String, Object>> snapshot = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            snapshot.add(crumb(i)); // oldest = event.0 ... newest = event.99
+        }
+
+        final int budget = 1024;
+        final List<Map<String, Object>> fitted = Raven.fitBreadcrumbsToBudget(base, snapshot, budget);
+
+        assertFalse("must keep a non-empty breadcrumb set", fitted.isEmpty());
+        assertTrue("must have trimmed", fitted.size() < snapshot.size());
+        assertTrue("must fit budget", serializedSize(base, fitted) <= budget);
+
+        // The kept crumbs are the newest contiguous tail, ending at the newest (event.99), ascending.
+        assertEquals(99, crumbIndex(fitted.get(fitted.size() - 1)));
+        final int first = crumbIndex(fitted.get(0));
+        for (int j = 0; j < fitted.size(); j++) {
+            assertEquals(first + j, crumbIndex(fitted.get(j)));
+        }
+    }
+
+    // Under budget: keep everything, in chronological order.
+    @Test
+    public void budgetKeepsAllWhenUnderBudget() {
+        final HashMap<String, Object> base = new HashMap<>();
+
+        final List<Map<String, Object>> snapshot = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            snapshot.add(crumb(i));
+        }
+
+        final List<Map<String, Object>> fitted = Raven.fitBreadcrumbsToBudget(base, snapshot, 64 * 1024);
+
+        assertEquals(5, fitted.size());
+        assertEquals(0, crumbIndex(fitted.get(0)));
+        assertEquals(4, crumbIndex(fitted.get(4)));
+    }
+
+    // Base payload alone already over budget: drop all breadcrumbs (the core report still sends).
+    @Test
+    public void budgetReturnsEmptyWhenBaseExceedsBudget() {
+        final HashMap<String, Object> base = new HashMap<>();
+        final StringBuilder huge = new StringBuilder();
+        for (int i = 0; i < 2000; i++) {
+            huge.append('x');
+        }
+        base.put("huge", huge.toString());
+
+        final List<Map<String, Object>> snapshot = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            snapshot.add(crumb(i));
+        }
+
+        final List<Map<String, Object>> fitted = Raven.fitBreadcrumbsToBudget(base, snapshot, 1024);
+
+        assertTrue(fitted.isEmpty());
     }
 }


### PR DESCRIPTION
Fixes the 4.3.13.beta0 release blocker from C-840 QA: accumulated breadcrumbs pushed the Sentry report past WorkManager's 10240-byte `Data` cap, so `Data.Builder.build()` threw `IllegalStateException` and the exception report was silently dropped.

**Fix — bound the payload by serialized size, not breadcrumb count:**
- `fitBreadcrumbsToBudget()` (public static, unit-testable) keeps the newest breadcrumbs that fit a conservative 8KB JSON budget — headroom for the endpoint/key/timestamp `Data` entries + WorkManager marshalling that also count toward the 10240 cap.
- Core breadcrumb-free report always sends; if `build()` still fails we log loudly and retry without breadcrumbs (backstop), never silently dropping again.
- `send()` null-guards the `Data` so a failed build can't enqueue a null-input request (which itself NPE'd in the repro).

**Intentional observability (ships):** `toData()` emits one `Log.d` per exception report — `Sentry report: N of M breadcrumbs kept, payload B bytes (size budget …)`. Debug level since trimming is normal operation; gives production visibility into whether the budget is engaging.

**Tests:** 3 new `RavenBreadcrumbTest` cases (trims-to-newest-non-empty, keeps-all-under-budget, empty-when-base-over-budget). 6/6 green.

**On-device verification** (Pixel 6a, cleanroom 4.3.13.beta0, exact native `ReportTestException` path):
- BEFORE: `IllegalStateException: Data cannot occupy more than 10240 bytes`, no POST (silent drop).
- AFTER: 13 of 100 crumbs @ 7716 bytes, no `IllegalStateException`, Sender worker POSTed to sentry.io → **HTTP 200**.

Note: clang-format not run locally (pinned version unavailable; local v21 reflows unrelated files) — touched code matched to surrounding style by hand; CI `validate-code-format` is the gate.

Linear: C-863
