### PR TITLE
maint: finalize 4.3.13 changelog

### DIFF
--- a/docs/modules/changelog/versions/4.3.13.yaml
+++ b/docs/modules/changelog/versions/4.3.13.yaml
@@ -1,10 +1,9 @@
 bug:
-  - "Fixed a crash (NPE) when claiming a reward if the server response was empty or had an unexpected shape. `TeakNotification.Reward.rewardFromRewardId` now resolves to a reward with `UNKNOWN` status instead of crashing or hanging."
-  - "Fixed `JSONException` Sentry noise from malformed server responses (HTML error pages, proxy errors) in request callbacks. Non-JSON bodies now fall back to `{}` and log a breadcrumb instead of hitting Sentry."
-  - "Fixed `UnsatisfiedLinkError` from `UnitySendMessage` being incorrectly reported to Sentry. `Method.invoke` wraps errors in `InvocationTargetException`; the catch block now correctly suppresses the wrapped form."
-  - "Reward links that resolve without an `AndroidPath` now retain the originating launch link for attribution instead of dropping it, matching the iOS resolver."
-  - "Fixed an `IllegalArgumentException` (\"Malformed escape pair\") when a deep link contained an unencoded `%` (e.g. a `50%` creative or schedule name). `DeepLink.willProcessUri` now guards `URI.create` the same way `processUri` already did, so such links no longer throw."
-  - "Fixed an Amazon Appstore SDK 3.x crash (`NoSuchFieldError`) and sandbox/production misclassification of purchases. Sandbox state now resolves via `LicensingService.getAppstoreSDKMode()` when that method is available, falling back to IAP v2.0's `IS_SANDBOX_MODE` otherwise."
+  - "Reward claims no longer hang on an empty or malformed server response."
+  - "Improved handling of malformed (non-JSON) server responses in network requests, which now degrade gracefully."
+  - "Universal links with malformed resolutions now keep their originating launch link for attribution instead of dropping it."
+  - "Improved handling of deep links containing an unencoded `%` (e.g. a `50%` creative or schedule name), which now route correctly."
+  - "Fixed a crash and incorrect sandbox/production purchase classification when using the Amazon Appstore SDK 3.x."
 
 enhancement:
-  - "Sentry exception reports now include breadcrumbs from recent `Teak.log` events, making crashes easier to diagnose."
+  - "Improved internal error reporting."


### PR DESCRIPTION
5 customer-facing bug fixes, internal Sentry/observability changes (C-685, C-737, C-738, C-863, run_id→tags) collapsed into "Improved internal error reporting."

Closes C-874