### PR TITLE
fix: resolve FCM sender ID lazily in onNewToken

### DIFF
--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,0 +1,2 @@
+bug:
+  - FCM registration no longer submits an empty sender ID when the framework delivers the first push token on a fresh install.

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,2 +1,2 @@
 bug:
-  - FCM registration no longer submits an empty sender ID when the framework delivers the first push token on a fresh install.
+  - FCM registration no longer omits the sender ID when the framework delivers the first push token on a fresh install.

--- a/src/main/java/io/teak/sdk/push/FCMPushProvider.java
+++ b/src/main/java/io/teak/sdk/push/FCMPushProvider.java
@@ -120,6 +120,7 @@ public class FCMPushProvider extends FirebaseMessagingService implements IPushPr
     public void onNewToken(@NonNull String token) {
         Teak.log.i("google.fcm.registered", Helpers.mm.h("fcmId", token));
         if (Teak.isEnabled()) {
+            ensureFirebaseApp();
             final String senderId = this.firebaseApp == null ? null : this.firebaseApp.getOptions().getGcmSenderId();
             TeakEvent.postEvent(new PushRegistrationEvent("gcm_push_key", token, senderId));
         }
@@ -134,16 +135,20 @@ public class FCMPushProvider extends FirebaseMessagingService implements IPushPr
         FCMPushProvider.onMessageReceivedExternal(remoteMessage, getApplicationContext(), false);
     }
 
-    //// IPushProvider
-
-    @Override
-    public void requestPushKey() {
+    private void ensureFirebaseApp() {
         if (this.firebaseApp == null) {
             try {
                 this.firebaseApp = FirebaseApp.getInstance();
             } catch (Exception ignored) {
             }
         }
+    }
+
+    //// IPushProvider
+
+    @Override
+    public void requestPushKey() {
+        ensureFirebaseApp();
 
         if (this.firebaseApp == null) {
             Teak.log.e("google.fcm.null_app", "Could not get Firebase App. Push notifications are unlikely to work.");


### PR DESCRIPTION
`FCMPushProvider.onNewToken` reads `this.firebaseApp` for the FCM sender ID, but that field is only set in `requestPushKey()`. On a fresh install, Android's framework delivers the first token via the `FirebaseMessagingService.onNewToken` override on a different service instance — `this.firebaseApp` is null and the submitted `gcm_sender_id` was empty.

Impact is cosmetic: the server validates the token via `Fcmv1::ValidateDeviceKey`, not the sender ID — the empty value only affects the diagnostic error-message wording when the token is invalid. But it produced a misleading "Firebase Configuration ()" message that cost debugging time during C-860/C-840 QA.

Fix: extract `private void ensureFirebaseApp()` (the same lazy `FirebaseApp.getInstance()` pattern already in `requestPushKey`) and call it from both sites. `FirebaseInitProvider` initializes the DEFAULT `FirebaseApp` as a ContentProvider before any `Service` can receive IPC, so `getInstance()` yields the real app — with the correct sender ID — by the time `onNewToken` fires.

https://linear.app/teakio/issue/C-862