### PR TITLE
Add debug-level Sentry POST logging to Sender (C-868)

### DIFF
--- a/src/main/java/io/teak/sdk/raven/Raven.java
+++ b/src/main/java/io/teak/sdk/raven/Raven.java
@@ -505,7 +505,9 @@ public class Raven implements Thread.UncaughtExceptionHandler {
             // Observability: how many breadcrumbs survived size-budgeting and the resulting
             // payload size. Fires once per exception report (rare); trimming is normal operation,
             // hence debug, not warn/error.
-            Log.d(LOG_TAG, "Sentry report: " + fitted.size() + " of " + this.breadcrumbSnapshot.size() + " breadcrumbs kept, payload " + payloadJson.getBytes(StandardCharsets.UTF_8).length + " bytes (size budget " + PAYLOAD_BUDGET_BYTES + ").");
+            Log.d(LOG_TAG, "Sentry report: " + fitted.size() + " of " + this.breadcrumbSnapshot.size()
+                               + " breadcrumbs kept, payload " + payloadJson.getBytes(StandardCharsets.UTF_8).length
+                               + " bytes (size budget " + PAYLOAD_BUDGET_BYTES + ").");
 
             Data data = this.buildData(payloadJson);
             if (data != null) {

--- a/src/main/java/io/teak/sdk/raven/Raven.java
+++ b/src/main/java/io/teak/sdk/raven/Raven.java
@@ -82,6 +82,7 @@ public class Raven implements Thread.UncaughtExceptionHandler {
     private final HashMap<String, Object> payloadTemplate = new HashMap<>();
     private final Context applicationContext;
     private final String appId;
+    private final boolean isDebug;
     private Thread.UncaughtExceptionHandler previousUncaughtExceptionHandler;
 
     private String SENTRY_KEY;
@@ -101,6 +102,7 @@ public class Raven implements Thread.UncaughtExceptionHandler {
 
         this.applicationContext = context;
         this.appId = appId;
+        this.isDebug = configuration.debugConfiguration.isDebug();
 
         final String proguardUuid = objectFactory.getAndroidResources().getStringResource(Raven.TEAK_SENTRY_PROGUARD_UUID);
         if (proguardUuid != null && proguardUuid.length() > 0) {
@@ -503,9 +505,7 @@ public class Raven implements Thread.UncaughtExceptionHandler {
             // Observability: how many breadcrumbs survived size-budgeting and the resulting
             // payload size. Fires once per exception report (rare); trimming is normal operation,
             // hence debug, not warn/error.
-            Log.d(LOG_TAG, "Sentry report: " + fitted.size() + " of " + this.breadcrumbSnapshot.size()
-                               + " breadcrumbs kept, payload " + payloadJson.getBytes(StandardCharsets.UTF_8).length
-                               + " bytes (size budget " + PAYLOAD_BUDGET_BYTES + ").");
+            Log.d(LOG_TAG, "Sentry report: " + fitted.size() + " of " + this.breadcrumbSnapshot.size() + " breadcrumbs kept, payload " + payloadJson.getBytes(StandardCharsets.UTF_8).length + " bytes (size budget " + PAYLOAD_BUDGET_BYTES + ").");
 
             Data data = this.buildData(payloadJson);
             if (data != null) {
@@ -534,6 +534,7 @@ public class Raven implements Thread.UncaughtExceptionHandler {
                     .putString(Sender.ENDPOINT_KEY, Raven.this.endpoint.toString())
                     .putString(Sender.SENTRY_KEY_KEY, Raven.this.SENTRY_KEY)
                     .putString(Sender.SENTRY_SECRET_KEY, Raven.this.SENTRY_SECRET)
+                    .putBoolean(Sender.DEBUG_KEY, Raven.this.isDebug)
                     .build();
             } catch (Exception e) {
                 Log.e(LOG_TAG, Log.getStackTraceString(e));

--- a/src/main/java/io/teak/sdk/raven/Sender.java
+++ b/src/main/java/io/teak/sdk/raven/Sender.java
@@ -108,7 +108,7 @@ public class Sender extends Worker {
             return Result.success();
         } catch (Exception e) {
             if (this.isDebug) {
-                Log.d(Raven.LOG_TAG, "Sentry POST exception: " + e);
+                Log.d(Raven.LOG_TAG, "Sentry POST exception: " + Log.getStackTraceString(e));
             }
             return Result.failure();
         } finally {

--- a/src/main/java/io/teak/sdk/raven/Sender.java
+++ b/src/main/java/io/teak/sdk/raven/Sender.java
@@ -1,6 +1,7 @@
 package io.teak.sdk.raven;
 
 import android.content.Context;
+import android.util.Log;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -29,12 +30,14 @@ public class Sender extends Worker {
     private final String sentryKey;
     private final String sentrySecret;
     private final long timestamp;
+    private final boolean isDebug;
 
     public static final String ENDPOINT_KEY = "endpoint";
     public static final String PAYLOAD_KEY = "payload";
     public static final String SENTRY_KEY_KEY = "SENTRY_KEY";
     public static final String SENTRY_SECRET_KEY = "SENTRY_SECRET";
     public static final String TIMESTAMP_KEY = "timestamp";
+    public static final String DEBUG_KEY = "debug";
 
     public Sender(@NonNull Context context, @NonNull WorkerParameters workerParams) throws MalformedURLException {
         super(context, workerParams);
@@ -45,6 +48,7 @@ public class Sender extends Worker {
         this.sentryKey = inputData.getString(SENTRY_KEY_KEY);
         this.sentrySecret = inputData.getString(SENTRY_SECRET_KEY);
         this.timestamp = inputData.getLong(TIMESTAMP_KEY, new Date().getTime() / 1000L);
+        this.isDebug = inputData.getBoolean(DEBUG_KEY, false);
     }
 
     @NonNull
@@ -74,8 +78,12 @@ public class Sender extends Worker {
             wr.flush();
             wr.close();
 
+            final int responseCode = connection.getResponseCode();
+            if (this.isDebug) {
+                Log.d(Raven.LOG_TAG, "Sentry POST HTTP " + responseCode);
+            }
             InputStream is;
-            if (connection.getResponseCode() < 400) {
+            if (responseCode < 400) {
                 is = connection.getInputStream();
             } else {
                 is = connection.getErrorStream();
@@ -98,7 +106,10 @@ public class Sender extends Worker {
             }
 
             return Result.success();
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            if (this.isDebug) {
+                Log.d(Raven.LOG_TAG, "Sentry POST exception: " + e);
+            }
             return Result.failure();
         } finally {
             if (rd != null) {


### PR DESCRIPTION
Closes the observability gap in the Sentry delivery chain exposed by C-863: Sender.doWork() previously logged nothing on its HTTP POST outcome, making it impossible to confirm whether a report reached Sentry without adding a temp log.

**Changes:**
- `Raven`: capture `debugConfiguration.isDebug()` at construction, thread it to `Sender` via WorkManager input Data (`DEBUG_KEY`)
- `Sender`: read the flag in constructor, gate `Log.d(Raven.LOG_TAG, "Sentry POST HTTP <code>")` on success/failure paths and exception logging on the catch path

https://linear.app/teakio/issue/C-868