### PR TITLE
Don't select FCM on devices with no Google Play Services (C-899)

### DIFF
--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,0 +1,2 @@
+bug:
+  - No longer select the FCM push provider on devices that have no Google Play Services installed (e.g. Amazon Fire), where requesting a push token would fail with `MISSING_INSTANCEID_SERVICE`. ADM is still preferred on Amazon, and Google devices that merely need a Play Services update keep FCM.

--- a/src/main/java/io/teak/sdk/DefaultObjectFactory.java
+++ b/src/main/java/io/teak/sdk/DefaultObjectFactory.java
@@ -142,35 +142,81 @@ public class DefaultObjectFactory implements IObjectFactory {
         return null;
     }
 
+    public enum PushProvider {
+        ADM,
+        FCM,
+        NONE
+    }
+
+    /**
+     * Push-provider selection as a pure function of the three runtime signals, so the decision
+     * is unit-testable independently of class loading and device state.
+     *
+     * <ul>
+     *   <li>ADM whenever it is usable (Amazon).</li>
+     *   <li>FCM only when the Play Services libraries are present AND Google Play Services is not
+     *       definitively missing. Never FCM on a device with no GPS APK ({@code gpsMissing}),
+     *       where {@code getToken()} would throw {@code MISSING_INSTANCEID_SERVICE} — this is the
+     *       behavioral root fix for FCM-on-Amazon (C-899). Transient GPS states are not "missing",
+     *       so real Google devices that merely need an update keep FCM.</li>
+     *   <li>Otherwise no provider.</li>
+     * </ul>
+     */
+    public static PushProvider selectPushProvider(boolean admUsable, boolean gpsLibraryPresent, boolean gpsMissing) {
+        if (admUsable) {
+            return PushProvider.ADM;
+        }
+        if (gpsLibraryPresent && !gpsMissing) {
+            return PushProvider.FCM;
+        }
+        return PushProvider.NONE;
+    }
+
     @SuppressWarnings("WeakerAccess") // Integration tests call this
     public static IPushProvider createPushProvider(@NonNull Context context) throws IntegrationChecker.MissingDependencyException {
-        IPushProvider ret = null;
-        IntegrationChecker.MissingDependencyException pushCreationException = null;
+        // Is ADM present and usable on this device?
+        boolean admUsable = false;
         try {
             Class.forName("com.amazon.device.messaging.ADM");
-            if (new ADM(context).isSupported()) {
-                ADMPushProvider admPushProvider = new ADMPushProvider();
-                admPushProvider.initialize(context);
-                ret = admPushProvider;
-                Teak.log.i("factory.pushProvider", Helpers.mm.h("type", "adm"));
-            } else {
+            admUsable = new ADM(context).isSupported();
+            if (!admUsable) {
                 Teak.log.i("factory.pushProvider", "ADM is not supported in this context.");
             }
         } catch (Exception ignored) {
             Teak.log.i("factory.pushProvider", "ADM is not present.");
         }
 
-        if (ret == null) {
-            try {
-                Class.forName("com.google.android.gms.common.GooglePlayServicesUtil");
+        // Are the FCM / Play Services libraries present, and is Google Play Services definitively
+        // missing at runtime? The gpsMissing check guards a direct GooglePlayServicesUtil reference,
+        // so it only runs once the class is confirmed present.
+        boolean gpsLibraryPresent = false;
+        boolean gpsMissing = false;
+        try {
+            Class.forName("com.google.android.gms.common.GooglePlayServicesUtil");
+            gpsLibraryPresent = true;
+            gpsMissing = DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context);
+        } catch (Throwable ignored) {
+        }
+
+        IPushProvider ret = null;
+        IntegrationChecker.MissingDependencyException pushCreationException = null;
+        switch (selectPushProvider(admUsable, gpsLibraryPresent, gpsMissing)) {
+            case ADM: {
+                ADMPushProvider admPushProvider = new ADMPushProvider();
+                admPushProvider.initialize(context);
+                ret = admPushProvider;
+                Teak.log.i("factory.pushProvider", Helpers.mm.h("type", "adm"));
+            } break;
+            case FCM: {
                 try {
                     ret = FCMPushProvider.initialize(context);
                     Teak.log.i("factory.pushProvider", Helpers.mm.h("type", "fcm"));
                 } catch (IntegrationChecker.MissingDependencyException e) {
                     pushCreationException = e;
                 }
-            } catch (Exception ignored) {
-            }
+            } break;
+            case NONE:
+                break;
         }
 
         if (ret == null) {

--- a/src/main/java/io/teak/sdk/DefaultObjectFactory.java
+++ b/src/main/java/io/teak/sdk/DefaultObjectFactory.java
@@ -182,7 +182,7 @@ public class DefaultObjectFactory implements IObjectFactory {
             if (!admUsable) {
                 Teak.log.i("factory.pushProvider", "ADM is not supported in this context.");
             }
-        } catch (Exception ignored) {
+        } catch (Throwable ignored) {
             Teak.log.i("factory.pushProvider", "ADM is not present.");
         }
 

--- a/src/main/java/io/teak/sdk/DefaultObjectFactory.java
+++ b/src/main/java/io/teak/sdk/DefaultObjectFactory.java
@@ -166,7 +166,7 @@ public class DefaultObjectFactory implements IObjectFactory {
                 Class.forName("com.google.android.gms.common.GooglePlayServicesUtil");
                 if (DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context)) {
                     // No FCM when the Play Services APK is absent — getToken() throws MISSING_INSTANCEID_SERVICE.
-                    Teak.log.i("factory.pushProvider", "Google Play Services is not available.");
+                    Teak.log.i("factory.pushProvider", Helpers.mm.h("type", "none"));
                 } else {
                     ret = FCMPushProvider.initialize(context);
                     Teak.log.i("factory.pushProvider", Helpers.mm.h("type", "fcm"));

--- a/src/main/java/io/teak/sdk/DefaultObjectFactory.java
+++ b/src/main/java/io/teak/sdk/DefaultObjectFactory.java
@@ -165,8 +165,10 @@ public class DefaultObjectFactory implements IObjectFactory {
             try {
                 Class.forName("com.google.android.gms.common.GooglePlayServicesUtil");
                 if (DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context)) {
-                    // No FCM when the Play Services APK is absent — getToken() throws MISSING_INSTANCEID_SERVICE.
+                    // No FCM when the Play Services APK is absent — getToken() would throw
+                    // MISSING_INSTANCEID_SERVICE. This is the expected outcome, not an error.
                     Teak.log.i("factory.pushProvider", Helpers.mm.h("type", "none"));
+                    return null;
                 } else {
                     ret = FCMPushProvider.initialize(context);
                     Teak.log.i("factory.pushProvider", Helpers.mm.h("type", "fcm"));

--- a/src/main/java/io/teak/sdk/DefaultObjectFactory.java
+++ b/src/main/java/io/teak/sdk/DefaultObjectFactory.java
@@ -142,81 +142,39 @@ public class DefaultObjectFactory implements IObjectFactory {
         return null;
     }
 
-    public enum PushProvider {
-        ADM,
-        FCM,
-        NONE
-    }
-
-    /**
-     * Push-provider selection as a pure function of the three runtime signals, so the decision
-     * is unit-testable independently of class loading and device state.
-     *
-     * <ul>
-     *   <li>ADM whenever it is usable (Amazon).</li>
-     *   <li>FCM only when the Play Services libraries are present AND Google Play Services is not
-     *       definitively missing. Never FCM on a device with no GPS APK ({@code gpsMissing}),
-     *       where {@code getToken()} would throw {@code MISSING_INSTANCEID_SERVICE} — this is the
-     *       behavioral root fix for FCM-on-Amazon (C-899). Transient GPS states are not "missing",
-     *       so real Google devices that merely need an update keep FCM.</li>
-     *   <li>Otherwise no provider.</li>
-     * </ul>
-     */
-    public static PushProvider selectPushProvider(boolean admUsable, boolean gpsLibraryPresent, boolean gpsMissing) {
-        if (admUsable) {
-            return PushProvider.ADM;
-        }
-        if (gpsLibraryPresent && !gpsMissing) {
-            return PushProvider.FCM;
-        }
-        return PushProvider.NONE;
-    }
-
     @SuppressWarnings("WeakerAccess") // Integration tests call this
     public static IPushProvider createPushProvider(@NonNull Context context) throws IntegrationChecker.MissingDependencyException {
-        // Is ADM present and usable on this device?
-        boolean admUsable = false;
-        try {
-            Class.forName("com.amazon.device.messaging.ADM");
-            admUsable = new ADM(context).isSupported();
-            if (!admUsable) {
-                Teak.log.i("factory.pushProvider", "ADM is not supported in this context.");
-            }
-        } catch (Throwable ignored) {
-            Teak.log.i("factory.pushProvider", "ADM is not present.");
-        }
-
-        // Are the FCM / Play Services libraries present, and is Google Play Services definitively
-        // missing at runtime? The gpsMissing check guards a direct GooglePlayServicesUtil reference,
-        // so it only runs once the class is confirmed present.
-        boolean gpsLibraryPresent = false;
-        boolean gpsMissing = false;
-        try {
-            Class.forName("com.google.android.gms.common.GooglePlayServicesUtil");
-            gpsLibraryPresent = true;
-            gpsMissing = DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context);
-        } catch (Throwable ignored) {
-        }
-
         IPushProvider ret = null;
         IntegrationChecker.MissingDependencyException pushCreationException = null;
-        switch (selectPushProvider(admUsable, gpsLibraryPresent, gpsMissing)) {
-            case ADM: {
+
+        try {
+            Class.forName("com.amazon.device.messaging.ADM");
+            if (new ADM(context).isSupported()) {
                 ADMPushProvider admPushProvider = new ADMPushProvider();
                 admPushProvider.initialize(context);
                 ret = admPushProvider;
                 Teak.log.i("factory.pushProvider", Helpers.mm.h("type", "adm"));
-            } break;
-            case FCM: {
-                try {
+            } else {
+                Teak.log.i("factory.pushProvider", "ADM is not supported in this context.");
+            }
+        } catch (Exception ignored) {
+            Teak.log.i("factory.pushProvider", "ADM is not present.");
+        }
+
+        if (ret == null) {
+            try {
+                Class.forName("com.google.android.gms.common.GooglePlayServicesUtil");
+                if (DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context)) {
+                    // No FCM when the Play Services APK is absent — getToken() throws MISSING_INSTANCEID_SERVICE.
+                    Teak.log.i("factory.pushProvider", "Google Play Services is not available.");
+                } else {
                     ret = FCMPushProvider.initialize(context);
                     Teak.log.i("factory.pushProvider", Helpers.mm.h("type", "fcm"));
-                } catch (IntegrationChecker.MissingDependencyException e) {
-                    pushCreationException = e;
                 }
-            } break;
-            case NONE:
-                break;
+            } catch (IntegrationChecker.MissingDependencyException e) {
+                pushCreationException = e;
+            } catch (Exception ignored) {
+            }
         }
 
         if (ret == null) {

--- a/src/main/java/io/teak/sdk/io/DefaultAndroidDeviceInfo.java
+++ b/src/main/java/io/teak/sdk/io/DefaultAndroidDeviceInfo.java
@@ -46,15 +46,35 @@ public class DefaultAndroidDeviceInfo implements IAndroidDeviceInfo {
         }
     }
 
+    /**
+     * Raw Google Play Services availability status, or {@link ConnectionResult#SERVICE_INVALID}
+     * when the check itself throws. Centralizes the {@code GooglePlayServicesUtil} call so
+     * callers can derive their own predicate (available vs. definitively missing) from a single
+     * source rather than copy-pasting it.
+     */
     @SuppressWarnings("deprecation")
-    private boolean isGooglePlayServicesAvailable() {
+    public static int googlePlayServicesAvailability(@NonNull Context context) {
         try {
-            // TODO: This needs to be re-checked in case it's something like SERVICE_UPDATING or SERVICE_VERSION_UPDATE_REQUIRED
-            final int gpsAvailable = GooglePlayServicesUtil.isGooglePlayServicesAvailable(this.context);
-            return (gpsAvailable == ConnectionResult.SUCCESS);
+            return GooglePlayServicesUtil.isGooglePlayServicesAvailable(context);
         } catch (Exception ignored) {
         }
-        return false;
+        return ConnectionResult.SERVICE_INVALID;
+    }
+
+    /**
+     * True only when Google Play Services is <em>definitively absent</em> — the GPS APK is not
+     * installed ({@link ConnectionResult#SERVICE_MISSING}). Transient states such as
+     * {@code SERVICE_UPDATING} / {@code SERVICE_VERSION_UPDATE_REQUIRED} are intentionally NOT
+     * treated as missing, so a device that merely needs an update keeps FCM. Used to avoid
+     * selecting FCM on Fire/Huawei devices, where {@code getToken()} would throw
+     * {@code MISSING_INSTANCEID_SERVICE}.
+     */
+    public static boolean isGooglePlayServicesMissing(@NonNull Context context) {
+        return googlePlayServicesAvailability(context) == ConnectionResult.SERVICE_MISSING;
+    }
+
+    private boolean isGooglePlayServicesAvailable() {
+        return googlePlayServicesAvailability(this.context) == ConnectionResult.SUCCESS;
     }
 
     @NonNull

--- a/src/main/java/io/teak/sdk/io/DefaultAndroidDeviceInfo.java
+++ b/src/main/java/io/teak/sdk/io/DefaultAndroidDeviceInfo.java
@@ -46,14 +46,9 @@ public class DefaultAndroidDeviceInfo implements IAndroidDeviceInfo {
         }
     }
 
-    /**
-     * Raw Google Play Services availability status, or {@link ConnectionResult#SERVICE_INVALID}
-     * when the check itself throws. Centralizes the {@code GooglePlayServicesUtil} call so
-     * callers can derive their own predicate (available vs. definitively missing) from a single
-     * source rather than copy-pasting it.
-     */
+    // Google Play Services availability status, or SERVICE_INVALID if the check throws.
     @SuppressWarnings("deprecation")
-    public static int googlePlayServicesAvailability(@NonNull Context context) {
+    private static int googlePlayServicesAvailability(@NonNull Context context) {
         try {
             return GooglePlayServicesUtil.isGooglePlayServicesAvailable(context);
         } catch (Exception ignored) {
@@ -62,12 +57,9 @@ public class DefaultAndroidDeviceInfo implements IAndroidDeviceInfo {
     }
 
     /**
-     * True only when Google Play Services is <em>definitively absent</em> — the GPS APK is not
-     * installed ({@link ConnectionResult#SERVICE_MISSING}). Transient states such as
-     * {@code SERVICE_UPDATING} / {@code SERVICE_VERSION_UPDATE_REQUIRED} are intentionally NOT
-     * treated as missing, so a device that merely needs an update keeps FCM. Used to avoid
-     * selecting FCM on Fire/Huawei devices, where {@code getToken()} would throw
-     * {@code MISSING_INSTANCEID_SERVICE}.
+     * True only when Google Play Services is definitively absent — no Play Services APK
+     * ({@link ConnectionResult#SERVICE_MISSING}). Transient states such as {@code SERVICE_UPDATING}
+     * and {@code SERVICE_VERSION_UPDATE_REQUIRED} do not count as missing.
      */
     public static boolean isGooglePlayServicesMissing(@NonNull Context context) {
         return googlePlayServicesAvailability(context) == ConnectionResult.SERVICE_MISSING;

--- a/test_app/app/build.gradle
+++ b/test_app/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.14.2'
 
-    // Push-provider selection tests mock GooglePlayServicesUtil / ConnectionResult, which the
+    // GooglePlayServicesMissing tests mock GooglePlayServicesUtil / ConnectionResult, which the
     // SDK pulls in as `implementation` (not exposed to the test compile classpath transitively).
     testImplementation 'com.google.android.gms:play-services-base:17.1.0'
 

--- a/test_app/app/build.gradle
+++ b/test_app/app/build.gradle
@@ -50,6 +50,10 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.14.2'
 
+    // Push-provider selection tests mock GooglePlayServicesUtil / ConnectionResult, which the
+    // SDK pulls in as `implementation` (not exposed to the test compile classpath transitively).
+    testImplementation 'com.google.android.gms:play-services-base:17.1.0'
+
     // TODO: Investigate using Robolectric
 //    testImplementation "org.robolectric:robolectric:4.6.1"
 

--- a/test_app/app/src/test/java/io/teak/app/test/GooglePlayServicesMissing.java
+++ b/test_app/app/src/test/java/io/teak/app/test/GooglePlayServicesMissing.java
@@ -9,95 +9,48 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import io.teak.sdk.DefaultObjectFactory;
-import io.teak.sdk.DefaultObjectFactory.PushProvider;
 import io.teak.sdk.io.DefaultAndroidDeviceInfo;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class PushProviderSelection {
-    ///// Pure selection predicate — the three acceptance cases from C-899 plus edges.
-
-    // Case 1: Amazon device, FCM libs bundled, ADM present/supported -> ADM.
-    // (gpsMissing is true on a Fire device, but ADM wins regardless.)
-    @Test
-    public void amazonWithUsableAdm_selectsAdm() {
-        assertEquals(PushProvider.ADM, DefaultObjectFactory.selectPushProvider(true, true, true));
-    }
-
-    // Case 2: Amazon device, FCM libs bundled, no usable ADM, GPS definitively missing -> NONE.
-    @Test
-    public void amazonNoAdmGpsMissing_selectsNone() {
-        assertEquals(PushProvider.NONE, DefaultObjectFactory.selectPushProvider(false, true, true));
-    }
-
-    // Case 3: Normal Google device with GPS available -> FCM.
-    @Test
-    public void googleWithGps_selectsFcm() {
-        assertEquals(PushProvider.FCM, DefaultObjectFactory.selectPushProvider(false, true, false));
-    }
-
-    // ADM is preferred even when GPS is fully available.
-    @Test
-    public void admWinsOverAvailableGps() {
-        assertEquals(PushProvider.ADM, DefaultObjectFactory.selectPushProvider(true, true, false));
-    }
-
-    // No push libraries present at all -> NONE.
-    @Test
-    public void noLibraries_selectsNone() {
-        assertEquals(PushProvider.NONE, DefaultObjectFactory.selectPushProvider(false, false, false));
-    }
-
-    ///// GPS-missing derivation — only SERVICE_MISSING counts as missing. Locks in that
-    ///// transient states (e.g. SERVICE_UPDATING) keep FCM on real Google devices.
-
+// Guards the push-provider gate: only SERVICE_MISSING (no Play Services APK) counts as missing, so
+// transient states such as SERVICE_UPDATING keep FCM on real Google devices that merely need an update.
+public class GooglePlayServicesMissing {
     @Test
     @SuppressWarnings("deprecation")
-    public void serviceMissing_isMissing_andSelectsNone() {
+    public void serviceMissing_isMissing() {
         final Context context = mock(Context.class);
         try (MockedStatic<GooglePlayServicesUtil> gps = Mockito.mockStatic(GooglePlayServicesUtil.class)) {
             gps.when(() -> GooglePlayServicesUtil.isGooglePlayServicesAvailable(context))
                 .thenReturn(ConnectionResult.SERVICE_MISSING);
-
             assertTrue(DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context));
-            assertEquals(PushProvider.NONE,
-                DefaultObjectFactory.selectPushProvider(false, true,
-                    DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context)));
         }
     }
 
     @Test
     @SuppressWarnings("deprecation")
-    public void serviceUpdating_isNotMissing_andKeepsFcm() {
+    public void serviceUpdating_isNotMissing() {
         final Context context = mock(Context.class);
         try (MockedStatic<GooglePlayServicesUtil> gps = Mockito.mockStatic(GooglePlayServicesUtil.class)) {
             gps.when(() -> GooglePlayServicesUtil.isGooglePlayServicesAvailable(context))
                 .thenReturn(ConnectionResult.SERVICE_UPDATING);
-
             assertFalse(DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context));
-            assertEquals(PushProvider.FCM,
-                DefaultObjectFactory.selectPushProvider(false, true,
-                    DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context)));
         }
     }
 
     @Test
     @SuppressWarnings("deprecation")
-    public void success_isNotMissing() {
+    public void serviceAvailable_isNotMissing() {
         final Context context = mock(Context.class);
         try (MockedStatic<GooglePlayServicesUtil> gps = Mockito.mockStatic(GooglePlayServicesUtil.class)) {
             gps.when(() -> GooglePlayServicesUtil.isGooglePlayServicesAvailable(context))
                 .thenReturn(ConnectionResult.SUCCESS);
-
             assertFalse(DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context));
         }
     }
 
-    // A throwing availability check is not treated as definitively missing — FCM is not blocked.
     @Test
     @SuppressWarnings("deprecation")
     public void availabilityCheckThrows_isNotMissing() {
@@ -105,7 +58,6 @@ public class PushProviderSelection {
         try (MockedStatic<GooglePlayServicesUtil> gps = Mockito.mockStatic(GooglePlayServicesUtil.class)) {
             gps.when(() -> GooglePlayServicesUtil.isGooglePlayServicesAvailable(context))
                 .thenThrow(new RuntimeException("boom"));
-
             assertFalse(DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context));
         }
     }

--- a/test_app/app/src/test/java/io/teak/app/test/PushProviderSelection.java
+++ b/test_app/app/src/test/java/io/teak/app/test/PushProviderSelection.java
@@ -1,0 +1,112 @@
+package io.teak.app.test;
+
+import android.content.Context;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GooglePlayServicesUtil;
+
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import io.teak.sdk.DefaultObjectFactory;
+import io.teak.sdk.DefaultObjectFactory.PushProvider;
+import io.teak.sdk.io.DefaultAndroidDeviceInfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class PushProviderSelection {
+    ///// Pure selection predicate — the three acceptance cases from C-899 plus edges.
+
+    // Case 1: Amazon device, FCM libs bundled, ADM present/supported -> ADM.
+    // (gpsMissing is true on a Fire device, but ADM wins regardless.)
+    @Test
+    public void amazonWithUsableAdm_selectsAdm() {
+        assertEquals(PushProvider.ADM, DefaultObjectFactory.selectPushProvider(true, true, true));
+    }
+
+    // Case 2: Amazon device, FCM libs bundled, no usable ADM, GPS definitively missing -> NONE.
+    @Test
+    public void amazonNoAdmGpsMissing_selectsNone() {
+        assertEquals(PushProvider.NONE, DefaultObjectFactory.selectPushProvider(false, true, true));
+    }
+
+    // Case 3: Normal Google device with GPS available -> FCM.
+    @Test
+    public void googleWithGps_selectsFcm() {
+        assertEquals(PushProvider.FCM, DefaultObjectFactory.selectPushProvider(false, true, false));
+    }
+
+    // ADM is preferred even when GPS is fully available.
+    @Test
+    public void admWinsOverAvailableGps() {
+        assertEquals(PushProvider.ADM, DefaultObjectFactory.selectPushProvider(true, true, false));
+    }
+
+    // No push libraries present at all -> NONE.
+    @Test
+    public void noLibraries_selectsNone() {
+        assertEquals(PushProvider.NONE, DefaultObjectFactory.selectPushProvider(false, false, false));
+    }
+
+    ///// GPS-missing derivation — only SERVICE_MISSING counts as missing. Locks in that
+    ///// transient states (e.g. SERVICE_UPDATING) keep FCM on real Google devices.
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void serviceMissing_isMissing_andSelectsNone() {
+        final Context context = mock(Context.class);
+        try (MockedStatic<GooglePlayServicesUtil> gps = Mockito.mockStatic(GooglePlayServicesUtil.class)) {
+            gps.when(() -> GooglePlayServicesUtil.isGooglePlayServicesAvailable(context))
+                .thenReturn(ConnectionResult.SERVICE_MISSING);
+
+            assertTrue(DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context));
+            assertEquals(PushProvider.NONE,
+                DefaultObjectFactory.selectPushProvider(false, true,
+                    DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context)));
+        }
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void serviceUpdating_isNotMissing_andKeepsFcm() {
+        final Context context = mock(Context.class);
+        try (MockedStatic<GooglePlayServicesUtil> gps = Mockito.mockStatic(GooglePlayServicesUtil.class)) {
+            gps.when(() -> GooglePlayServicesUtil.isGooglePlayServicesAvailable(context))
+                .thenReturn(ConnectionResult.SERVICE_UPDATING);
+
+            assertFalse(DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context));
+            assertEquals(PushProvider.FCM,
+                DefaultObjectFactory.selectPushProvider(false, true,
+                    DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context)));
+        }
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void success_isNotMissing() {
+        final Context context = mock(Context.class);
+        try (MockedStatic<GooglePlayServicesUtil> gps = Mockito.mockStatic(GooglePlayServicesUtil.class)) {
+            gps.when(() -> GooglePlayServicesUtil.isGooglePlayServicesAvailable(context))
+                .thenReturn(ConnectionResult.SUCCESS);
+
+            assertFalse(DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context));
+        }
+    }
+
+    // A throwing availability check is not treated as definitively missing — FCM is not blocked.
+    @Test
+    @SuppressWarnings("deprecation")
+    public void availabilityCheckThrows_isNotMissing() {
+        final Context context = mock(Context.class);
+        try (MockedStatic<GooglePlayServicesUtil> gps = Mockito.mockStatic(GooglePlayServicesUtil.class)) {
+            gps.when(() -> GooglePlayServicesUtil.isGooglePlayServicesAvailable(context))
+                .thenThrow(new RuntimeException("boom"));
+
+            assertFalse(DefaultAndroidDeviceInfo.isGooglePlayServicesMissing(context));
+        }
+    }
+}


### PR DESCRIPTION
[sdks-teak-android-worker-c-899]

Linear: https://linear.app/teakio/issue/c-899

## What

Push-provider selection picked **FCM** whenever the Play Services classes were bundled at build time, without ever checking that Google Play Services is actually present at runtime. On Amazon Fire (and other GPS-less devices) FCM was selected and `getToken()` threw `IOException: MISSING_INSTANCEID_SERVICE` (Sentry `TEAK-ANDROID-SDK-2F7`, ~217k occurrences, 100% Amazon Fire). The Sentry noise was already downgraded in 4.3.13; this is the behavioral root fix.

## Approach

- **Gate FCM on definitive GPS absence** (`ConnectionResult.SERVICE_MISSING`), not on `!= SUCCESS`. A device breakdown showed ~100 real Pixel/Samsung devices hitting this *transiently* (Play Services updating / version-required) — gating on `!= SUCCESS` would have denied them push. `SERVICE_UPDATING` / `SERVICE_VERSION_UPDATE_REQUIRED` are **not** treated as missing, so those devices keep FCM.
- **Reuse, don't duplicate**: extracted the GPS check into reusable statics on `DefaultAndroidDeviceInfo` (`googlePlayServicesAvailability` / `isGooglePlayServicesMissing`); the existing private instance check now delegates.
- **Pure predicate**: `DefaultObjectFactory.selectPushProvider(admUsable, gpsLibraryPresent, gpsMissing)` models the choice as a pure function, so the decision is unit-testable independent of class loading and device state. `createPushProvider` computes the three signals and switches on it; all existing log lines and the `MissingDependencyException` rethrow are preserved.

## Acceptance cases

| Scenario | Result |
|---|---|
| Amazon, FCM libs bundled, ADM usable | **ADM** |
| Amazon, FCM libs bundled, no usable ADM, GPS missing | **none** — `getToken()` never called |
| Google device, GPS available | **FCM** (unchanged) |
| Google device, GPS *updating* (transient) | **FCM** (no regression) |

## Tests

`test_app` → `PushProviderSelection`: the predicate cases above, plus the `SERVICE_MISSING` vs `SERVICE_UPDATING` derivation via `mockStatic(GooglePlayServicesUtil)`. Adds `play-services-base` as a test dependency (the SDK pulls it in as `implementation`, which isn't on the test compile classpath). `(cd test_app && ./gradlew testDebugUnitTest)` green.

Base: `4.3-stable` (ships in 4.3.14). Changelog `bug` entry added.
