### PR TITLE
Drain pre-configuration log events into the Raven as breadcrumbs

### DIFF
--- a/src/main/java/io/teak/sdk/Log.java
+++ b/src/main/java/io/teak/sdk/Log.java
@@ -190,8 +190,23 @@ public class Log {
     private volatile Raven sdkRaven;
 
     // Kept in sync with TeakInstance.sdkRaven by the TeakConfiguration listener in TeakInstance.
+    //
+    // On the first call this also drains any log events that were queued before configuration was
+    // ready, replaying them through the now-available Raven as breadcrumbs. TeakInstance creates the
+    // Raven from a TeakConfiguration listener that fires after Log's own listener, so this is the
+    // earliest point the Raven exists -- draining here is what gives pre-configuration events
+    // breadcrumbs, aligning Android's observable behavior with iOS. See C-740.
     public void setSdkRaven(Raven raven) {
-        this.sdkRaven = raven;
+        synchronized (queuedLogEvents) {
+            this.sdkRaven = raven;
+            if (!processedQueuedLogEvents) {
+                for (LogEvent event : queuedLogEvents) {
+                    logEvent(event, raven);
+                }
+                queuedLogEvents.clear();
+                processedQueuedLogEvents = true;
+            }
+        }
     }
 
     private Teak.LogListener logListener;
@@ -232,12 +247,8 @@ public class Log {
                 // Log data collection configuration
                 log(Level.Info, "configuration.data_collection", configuration.dataCollectionConfiguration.toMap());
 
-                synchronized (queuedLogEvents) {
-            for (LogEvent event : queuedLogEvents) {
-                logEvent(event, null);
-            }
-            processedQueuedLogEvents = true;
-                }
+        // Queued pre-configuration events are drained in setSdkRaven(), once the Raven
+        // exists, so they land as breadcrumbs. See C-740.
     }
 });
 }

--- a/src/main/java/io/teak/sdk/Log.java
+++ b/src/main/java/io/teak/sdk/Log.java
@@ -189,13 +189,10 @@ public class Log {
 
     private volatile Raven sdkRaven;
 
-    // Kept in sync with TeakInstance.sdkRaven by the TeakConfiguration listener in TeakInstance.
-    //
-    // On the first call this also drains any log events that were queued before configuration was
-    // ready, replaying them through the now-available Raven as breadcrumbs. TeakInstance creates the
-    // Raven from a TeakConfiguration listener that fires after Log's own listener, so this is the
-    // earliest point the Raven exists -- draining here is what gives pre-configuration events
-    // breadcrumbs, aligning Android's observable behavior with iOS. See C-740.
+    // Kept in sync with TeakInstance.sdkRaven. The first call also drains events logged before
+    // configuration was ready, replaying them through the now-available Raven as breadcrumbs --
+    // the listener that creates the Raven fires after Log's own, so this is the earliest point it
+    // exists and the only place those queued events can become breadcrumbs.
     public void setSdkRaven(Raven raven) {
         synchronized (queuedLogEvents) {
             this.sdkRaven = raven;
@@ -247,8 +244,7 @@ public class Log {
                 // Log data collection configuration
                 log(Level.Info, "configuration.data_collection", configuration.dataCollectionConfiguration.toMap());
 
-        // Queued pre-configuration events are drained in setSdkRaven(), once the Raven
-        // exists, so they land as breadcrumbs. See C-740.
+        // Pre-configuration events are drained in setSdkRaven(), once the Raven exists.
     }
 });
 }

--- a/src/main/java/io/teak/sdk/TeakInstance.java
+++ b/src/main/java/io/teak/sdk/TeakInstance.java
@@ -66,8 +66,16 @@ public class TeakInstance implements Unobfuscable {
 
         // Ravens
         TeakConfiguration.addEventListener(configuration -> {
-            TeakInstance.this.sdkRaven = new Raven(context, "sdk", configuration, objectFactory);
-            Teak.log.setSdkRaven(TeakInstance.this.sdkRaven);
+            try {
+                TeakInstance.this.sdkRaven = new Raven(context, "sdk", configuration, objectFactory);
+            } finally {
+                // Always hand the (possibly null) Raven to Log so it drains the pre-configuration
+                // event queue even if Raven construction throws. The exception still propagates and
+                // is swallowed by Teak.onCreate's catch, leaving the SDK disabled but the host app
+                // running -- without this, the queued events would be silently lost. setSdkRaven
+                // drains through a null Raven (events logged, breadcrumbs skipped). See C-740.
+                Teak.log.setSdkRaven(TeakInstance.this.sdkRaven);
+            }
             TeakInstance.this.appRaven = new Raven(context, configuration.appConfiguration.bundleId, configuration, objectFactory);
         });
 

--- a/src/main/java/io/teak/sdk/TeakInstance.java
+++ b/src/main/java/io/teak/sdk/TeakInstance.java
@@ -69,11 +69,11 @@ public class TeakInstance implements Unobfuscable {
             try {
                 TeakInstance.this.sdkRaven = new Raven(context, "sdk", configuration, objectFactory);
             } finally {
-                // Always hand the (possibly null) Raven to Log so it drains the pre-configuration
-                // event queue even if Raven construction throws. The exception still propagates and
-                // is swallowed by Teak.onCreate's catch, leaving the SDK disabled but the host app
-                // running -- without this, the queued events would be silently lost. setSdkRaven
-                // drains through a null Raven (events logged, breadcrumbs skipped). See C-740.
+                // Always hand the (possibly null) Raven to Log so the pre-configuration event
+                // queue drains even if the Raven constructor throws. The exception still unwinds
+                // and disables the SDK (Teak.onCreate catches it, so the host app keeps running),
+                // and without this the queued events would be silently lost. A null Raven still
+                // drains (events logged, breadcrumbs skipped).
                 Teak.log.setSdkRaven(TeakInstance.this.sdkRaven);
             }
             TeakInstance.this.appRaven = new Raven(context, configuration.appConfiguration.bundleId, configuration, objectFactory);

--- a/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
@@ -77,6 +77,35 @@ public class RavenBreadcrumbTest extends TeakUnitTest {
         assertTrue("pre-configuration log event must replay into the raven as a breadcrumb", found);
     }
 
+    // C-740 (C-863 positive-proof): the null-Raven fallback. TeakInstance hands setSdkRaven a
+    // possibly-null Raven from a try/finally, so the queue still drains if Raven construction throws
+    // -- otherwise the queued pre-config events would be silently lost when Teak.onCreate swallows
+    // the exception and the SDK runs on disabled. With a null Raven the events must still flush
+    // through logEvent (observed here via a LogListener); breadcrumbs are skipped because there is
+    // no Raven to receive them.
+    @Test
+    public void nullRavenStillFlushesQueuedEventsAsLogs() {
+        final Log log = new Log("Teak.Test", 0);
+
+        final List<String> flushed = new ArrayList<>();
+        log.setLogListener(new Teak.LogListener() {
+            @Override
+            public void logEvent(String logEvent, String logLevel, Map<String, Object> logData) {
+                if ("pre.config.event".equals(logEvent)) {
+                    flushed.add(logEvent);
+                }
+            }
+        });
+
+        log.i("pre.config.event", "fired before the raven existed");
+        assertTrue("queued event must not flush before setSdkRaven drains the queue", flushed.isEmpty());
+
+        // Raven-construction-failed path: a null Raven must still drain the queue.
+        log.setSdkRaven(null);
+
+        assertEquals("queued event must flush as a log even with a null raven", 1, flushed.size());
+    }
+
     @Test
     public void breadcrumbCapAt100() throws Exception {
         Raven raven = makeRaven();

--- a/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.teak.sdk.Log;
 import io.teak.sdk.Teak;
 import io.teak.sdk.TeakConfiguration;
 import io.teak.sdk.json.JSONObject;
@@ -48,6 +49,32 @@ public class RavenBreadcrumbTest extends TeakUnitTest {
         assertEquals("test.breadcrumb", crumb.get("category"));
         assertEquals("info", crumb.get("level"));
         assertTrue(crumb.containsKey("timestamp"));
+    }
+
+    // C-740 regression: an event logged before configuration is ready (before the Raven exists) is
+    // queued and must replay into the Raven as a breadcrumb when setSdkRaven() is called. A fresh
+    // Log reproduces the pre-configuration window deterministically -- the singleton Teak.log is
+    // already past it. Reverting the fix (draining in the config listener with a null Raven) drops
+    // the event, leaving it absent from the snapshot, and fails this test.
+    @Test
+    public void preConfigurationEventReplaysAsBreadcrumbWhenRavenIsSet() {
+        final Log log = new Log("Teak.Test", 0);
+
+        // Logged before the Raven exists -- queued, not yet a breadcrumb.
+        log.i("pre.config.event", "fired before the raven existed");
+
+        final Raven raven = makeRaven();
+        log.setSdkRaven(raven);
+
+        boolean found = false;
+        for (Map<String, Object> crumb : raven.snapshotBreadcrumbs()) {
+            if ("pre.config.event".equals(crumb.get("category"))) {
+                assertEquals("info", crumb.get("level"));
+                found = true;
+                break;
+            }
+        }
+        assertTrue("pre-configuration log event must replay into the raven as a breadcrumb", found);
     }
 
     @Test

--- a/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/RavenBreadcrumbTest.java
@@ -51,11 +51,9 @@ public class RavenBreadcrumbTest extends TeakUnitTest {
         assertTrue(crumb.containsKey("timestamp"));
     }
 
-    // C-740 regression: an event logged before configuration is ready (before the Raven exists) is
-    // queued and must replay into the Raven as a breadcrumb when setSdkRaven() is called. A fresh
-    // Log reproduces the pre-configuration window deterministically -- the singleton Teak.log is
-    // already past it. Reverting the fix (draining in the config listener with a null Raven) drops
-    // the event, leaving it absent from the snapshot, and fails this test.
+    // An event logged before configuration is ready (before the Raven exists) is queued and must
+    // replay into the Raven as a breadcrumb when setSdkRaven() is called. A fresh Log reproduces
+    // the pre-configuration window deterministically; the singleton Teak.log is already past it.
     @Test
     public void preConfigurationEventReplaysAsBreadcrumbWhenRavenIsSet() {
         final Log log = new Log("Teak.Test", 0);
@@ -77,12 +75,10 @@ public class RavenBreadcrumbTest extends TeakUnitTest {
         assertTrue("pre-configuration log event must replay into the raven as a breadcrumb", found);
     }
 
-    // C-740 (C-863 positive-proof): the null-Raven fallback. TeakInstance hands setSdkRaven a
-    // possibly-null Raven from a try/finally, so the queue still drains if Raven construction throws
-    // -- otherwise the queued pre-config events would be silently lost when Teak.onCreate swallows
-    // the exception and the SDK runs on disabled. With a null Raven the events must still flush
-    // through logEvent (observed here via a LogListener); breadcrumbs are skipped because there is
-    // no Raven to receive them.
+    // The null-Raven fallback. TeakInstance hands setSdkRaven a possibly-null Raven from a
+    // try/finally, so the queue still drains even if Raven construction throws -- otherwise the
+    // queued events would be silently lost. With a null Raven the events still flush through
+    // logEvent (observed here via a LogListener); breadcrumbs are skipped, as there is no Raven.
     @Test
     public void nullRavenStillFlushesQueuedEventsAsLogs() {
         final Log log = new Log("Teak.Test", 0);


### PR DESCRIPTION
[sdks-teak-android-worker-c-740]

## What
Pre-configuration log events now land as Sentry breadcrumbs on Android, matching iOS's observable behavior.

## Why
Log events fired before `TeakConfiguration` is ready are queued in `Log.queuedLogEvents`. They were drained by Log's own config listener passing a **`null`** Raven, so they never became breadcrumbs. The SDK Raven is created by a *separate* `TeakConfiguration` listener in `TeakInstance` that registers — and fires — after Log's, so even a non-null drain there would have seen `null`. Two stacked bugs.

## How
Move the drain into `Log.setSdkRaven()`: on its first call it replays the queued events through the now-available Raven and clears the queue. `TeakInstance` calls `setSdkRaven()` from its post-Log config listener, so the Raven definitionally exists at drain time. Log's config listener no longer drains.

Regression test (fresh `Log` → pre-config event → `setSdkRaven` → crumb in the report snapshot) fails if the drain/order regresses — verified by reverting the fix.

## Raven-ctor-throws guard
`new Raven("sdk")` can throw a `RuntimeException`, which unwinds past `setSdkRaven` and is swallowed by `Teak.onCreate`'s broad `catch (Exception)` (`Teak.java:204`) — the host app survives, Teak goes dark, and the queued events are **silently lost** (C-863 shape). `TeakInstance` now wraps the assignment in `try/finally` so `setSdkRaven()` is always reached with the (possibly `null`) Raven; the drain flushes events as logs even with a null Raven (breadcrumbs skipped). The exception still propagates and disables the SDK — only the silent loss is gone.

A Log-level regression test asserts the null-Raven path still flushes queued events (observed via a `LogListener`). **The 3-line `try/finally` wiring itself is review-verified only, not test-covered:** the integration-level test — driving the listener through a throwing `IObjectFactory` for red-on-removal of the `finally` — needs `onCreate` + Robolectric scaffolding the harness lacks (Robolectric disabled at `build.gradle:58`, package-private `TeakInstance` ctor; same C-367 boundary).

## Scope
This is the minimal init-order fix (Option A) for 4.3.14. The broader iOS-parity work — a decoupled global breadcrumb buffer (Option B, from Alex's PR #148 comment) — is tracked as a separate develop follow-up.

Linear: https://linear.app/teakio/issue/C-740
