### PR TITLE
Fix format-code/validate-code-format vendored-path and .java gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,11 +27,12 @@ These run in CI and will fail the build if violated:
 
 - **`./org_json_check`** — No imports of `org.json.*` allowed. Must use vendored `io.teak.sdk.json.*` (exists to avoid Android API < 19 differences).
 - **`./check_thread_use`** — No direct `import java.util.concurrent.Executors` except in `Executors.java`. All executor creation goes through `io.teak.sdk.core.Executors`.
-- **`./validate-code-format`** — clang-format validation (also runs as pre-commit hook).
+
+`./validate-code-format` is **not** run by CI — it's local-only, wired up as a pre-commit hook (`pre-commit` → `./validate-code-format`). It's the sole enforcement point for clang-format style, including `.java`.
 
 ## Code Style
 
-- **clang-format** enforced (config in `.clang-format`)
+- **clang-format** enforced (config in `.clang-format`); baseline-verified against clang-format 21.1.8 — a different version can produce spurious diffs on otherwise-conformant files
 - 4-space indent, no column limit, K&R braces
 - `BreakAfterJavaFieldAnnotations: true`
 - Vendored code (`shortcutbadger/`, `json/`) is excluded from formatting and linting

--- a/format-code
+++ b/format-code
@@ -2,4 +2,4 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-find src -not \( -path src/main/java/io/teak/sdk/shortcutbadger -prune \) -type f -name "*.java" | xargs clang-format -style=file -i
+find src \( -path src/main/java/io/teak/sdk/shortcutbadger -o -path src/main/java/io/teak/sdk/json \) -prune -o -type f -name "*.java" -print | xargs clang-format -style=file -i

--- a/src/main/java/io/teak/sdk/NotificationBuilder.java
+++ b/src/main/java/io/teak/sdk/NotificationBuilder.java
@@ -243,7 +243,7 @@ public class NotificationBuilder {
         final String contentTextTemplate = "{{ notification_count }} new messages";
 
         String contentTitle = null;
-        if(contentTitleTemplate != null) {
+        if (contentTitleTemplate != null) {
             contentTitle = contentTitleTemplate.replaceAll("\\{\\{\\h*notification_count\\h*\\}\\}", Integer.toString(notificationCount));
         } else {
             contentTitle = applicationName;
@@ -252,15 +252,15 @@ public class NotificationBuilder {
         final String contentText = contentTextTemplate.replaceAll("\\{\\{\\h*notification_count\\h*\\}\\}", Integer.toString(notificationCount));
         final NotificationCompat.InboxStyle style = new NotificationCompat.InboxStyle().setBigContentTitle(contentText);
 
-        for(Notification notification : notifications) {
+        for (Notification notification : notifications) {
             final Bundle extras = notification.extras;
             final String notifTitle = extras.getString(NotificationCompat.EXTRA_TITLE);
             final String notifText = extras.getString(NotificationCompat.EXTRA_TEXT);
             final String title = notifTitle == null ? "" : notifTitle;
             final String text = notifText == null ? "" : notifText;
-            if(title.length() > 0 || text.length() > 0) {
+            if (title.length() > 0 || text.length() > 0) {
                 final SpannableString line = new SpannableString(title + text);
-                if(title.length() > 0) {
+                if (title.length() > 0) {
                     line.setSpan(new StyleSpan(Typeface.BOLD), 0, title.length(), 0);
                 }
                 style.addLine(line);
@@ -273,15 +273,14 @@ public class NotificationBuilder {
         builder.setContentIntent(mostRecentNotif.contentIntent);
 
         return builder.setGroup(groupKey)
-                .setGroupSummary(true)
-                .setOnlyAlertOnce(true)
-                .setAutoCancel(false)
-                .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
-                .setContentText(contentText)
-                .setContentTitle(contentTitle)
-                .setStyle(style)
-                .build();
-
+            .setGroupSummary(true)
+            .setOnlyAlertOnce(true)
+            .setAutoCancel(false)
+            .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
+            .setContentText(contentText)
+            .setContentTitle(contentTitle)
+            .setStyle(style)
+            .build();
     }
 
     private static boolean isHostAppDebug() {
@@ -362,9 +361,9 @@ public class NotificationBuilder {
 
                     if (soundUri != null) {
                         final AudioAttributes audioAttributes = new AudioAttributes.Builder()
-                                .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                                .build();
+                                                                    .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                                                                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                                                                    .build();
                         channel.setSound(soundUri, audioAttributes);
                     }
                 }
@@ -560,67 +559,67 @@ public class NotificationBuilder {
                         final String value = viewConfig.getString(key);
                         remoteViews.setViewVisibility(viewElementId, View.VISIBLE);
                         remoteViews.setTextViewText(viewElementId, fromHtml(value));
-                    } else //noinspection StatementWithEmptyBody
+                    } else // noinspection StatementWithEmptyBody
                         if (isUIType(viewElement, ImageButton.class)) {
-                        // ImageButton must go before ImageView, because ImageButton is a ImageView
-                    } else if (isUIType(viewElement, ImageView.class)) {
-                        final String value = viewConfig.getString(key);
-                        if (value.equalsIgnoreCase("BUILTIN_APP_ICON")) {
-                            remoteViews.setImageViewResource(viewElementId, R.appIconResourceId);
-                        } else if (value.equalsIgnoreCase("NONE")) {
-                            remoteViews.setViewVisibility(viewElementId, View.GONE);
-                        } else {
-                            final Result<Bitmap> bitmapResult = loadBitmapWithOOMFallbacks(key, viewConfig);
-                            if (bitmapResult.value == null) {
-                                // If an asset failed to load, throw an AssetLoadException, unless it's
-                                // the "left_image" in which case just ignore it.
-                                if (!"left_image".equals(key)) {
-                                    throw new AssetLoadException(value, bitmapResult.error);
-                                }
+                            // ImageButton must go before ImageView, because ImageButton is a ImageView
+                        } else if (isUIType(viewElement, ImageView.class)) {
+                            final String value = viewConfig.getString(key);
+                            if (value.equalsIgnoreCase("BUILTIN_APP_ICON")) {
+                                remoteViews.setImageViewResource(viewElementId, R.appIconResourceId);
+                            } else if (value.equalsIgnoreCase("NONE")) {
+                                remoteViews.setViewVisibility(viewElementId, View.GONE);
                             } else {
-                                remoteViews.setImageViewBitmap(viewElementId, bitmapResult.value);
-                            }
-                        }
-                    } else if (isUIType(viewElement, ViewFlipper.class)) {
-                        final Result<AnimationConfiguration> animationConfigResult = loadAnimationConfigWithOOMFallbacks(viewConfig);
-                        if (animationConfigResult.value == null) {
-                            final JSONObject jsonConfig = viewConfig.getJSONObject("view_animator");
-                            throw new AssetLoadException(jsonConfig.getString("sprite_sheet"), animationConfigResult.error);
-                        } else if (animationConfigResult.value.spriteSheet == null) {
-                            throw new AssetLoadException(animationConfigResult.value.spriteSheetUrl, animationConfigResult.error);
-                        }
-                        final Bitmap bitmap = animationConfigResult.value.spriteSheet;
-                        final int frameWidth = animationConfigResult.value.width;
-                        final int frameHeight = animationConfigResult.value.height;
-                        final int msPerFrame = animationConfigResult.value.displayMs;
-
-                        final int numCols = bitmap.getWidth() / frameWidth;
-                        final int numRows = bitmap.getHeight() / frameHeight;
-
-                        for (int x = 0; x < numCols; x++) {
-                            for (int y = 0; y < numRows; y++) {
-                                final int startX = x * frameWidth;
-                                final int startY = y * frameHeight;
-                                Bitmap frame = Bitmap.createBitmap(bitmap, startX, startY, frameWidth, frameHeight);
-
-                                if (frame == null) {
-                                    throw new IllegalArgumentException("Frame [" + x + ", " + y + "] is null (" + animationConfigResult.value.spriteSheetUrl + ")");
+                                final Result<Bitmap> bitmapResult = loadBitmapWithOOMFallbacks(key, viewConfig);
+                                if (bitmapResult.value == null) {
+                                    // If an asset failed to load, throw an AssetLoadException, unless it's
+                                    // the "left_image" in which case just ignore it.
+                                    if (!"left_image".equals(key)) {
+                                        throw new AssetLoadException(value, bitmapResult.error);
+                                    }
+                                } else {
+                                    remoteViews.setImageViewBitmap(viewElementId, bitmapResult.value);
                                 }
-
-                                final RemoteViews frameView = new RemoteViews(context.getPackageName(),
-                                    isLargeView ? R.layout("teak_big_frame") : R.layout("teak_frame"));
-                                final int frameViewId = R.id("notification_background");
-                                frameView.setImageViewBitmap(frameViewId, frame);
-                                remoteViews.addView(viewElementId, frameView);
                             }
+                        } else if (isUIType(viewElement, ViewFlipper.class)) {
+                            final Result<AnimationConfiguration> animationConfigResult = loadAnimationConfigWithOOMFallbacks(viewConfig);
+                            if (animationConfigResult.value == null) {
+                                final JSONObject jsonConfig = viewConfig.getJSONObject("view_animator");
+                                throw new AssetLoadException(jsonConfig.getString("sprite_sheet"), animationConfigResult.error);
+                            } else if (animationConfigResult.value.spriteSheet == null) {
+                                throw new AssetLoadException(animationConfigResult.value.spriteSheetUrl, animationConfigResult.error);
+                            }
+                            final Bitmap bitmap = animationConfigResult.value.spriteSheet;
+                            final int frameWidth = animationConfigResult.value.width;
+                            final int frameHeight = animationConfigResult.value.height;
+                            final int msPerFrame = animationConfigResult.value.displayMs;
+
+                            final int numCols = bitmap.getWidth() / frameWidth;
+                            final int numRows = bitmap.getHeight() / frameHeight;
+
+                            for (int x = 0; x < numCols; x++) {
+                                for (int y = 0; y < numRows; y++) {
+                                    final int startX = x * frameWidth;
+                                    final int startY = y * frameHeight;
+                                    Bitmap frame = Bitmap.createBitmap(bitmap, startX, startY, frameWidth, frameHeight);
+
+                                    if (frame == null) {
+                                        throw new IllegalArgumentException("Frame [" + x + ", " + y + "] is null (" + animationConfigResult.value.spriteSheetUrl + ")");
+                                    }
+
+                                    final RemoteViews frameView = new RemoteViews(context.getPackageName(),
+                                        isLargeView ? R.layout("teak_big_frame") : R.layout("teak_frame"));
+                                    final int frameViewId = R.id("notification_background");
+                                    frameView.setImageViewBitmap(frameViewId, frame);
+                                    remoteViews.addView(viewElementId, frameView);
+                                }
+                            }
+
+                            // Set frame rate
+                            remoteViews.setInt(viewElementId, "setFlipInterval", msPerFrame);
+
+                            // Mark notification as containing animated element(s)
+                            teakNotificaton.isAnimated = true;
                         }
-
-                        // Set frame rate
-                        remoteViews.setInt(viewElementId, "setFlipInterval", msPerFrame);
-
-                        // Mark notification as containing animated element(s)
-                        teakNotificaton.isAnimated = true;
-                    }
                     // TODO: Else, report error to dashboard.
                 }
 

--- a/src/main/java/io/teak/sdk/Teak.java
+++ b/src/main/java/io/teak/sdk/Teak.java
@@ -133,7 +133,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
         try {
             if (intent != null && intent.getData() != null) {
                 final Uri intentData = intent.getData();
-                if(intentData.isHierarchical()) {
+                if (intentData.isHierarchical()) {
                     if (intentData.getBooleanQueryParameter("teak_log", false)) {
                         Teak.forceDebug = true;
                     }
@@ -150,14 +150,14 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
                     if (intentData.getBooleanQueryParameter("teak_strict_mode", false)) {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                             StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
-                                                       .detectNonSdkApiUsage()
-                                                       .penaltyLog()
-                                                       .build());
+                                    .detectNonSdkApiUsage()
+                                    .penaltyLog()
+                                    .build());
                         }
                     }
                 }
             }
-        } catch(Exception e) {
+        } catch (Exception e) {
             android.util.Log.e(LOG_TAG, android.util.Log.getStackTraceString(e));
         }
 
@@ -495,7 +495,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
             SMS("sms"),                    ///< SMS channel
             Invalid("invalid");            ///< Invalid channel, will be ignored if used
 
-            //public static final Integer length = 1 + Invalid.ordinal();
+            // public static final Integer length = 1 + Invalid.ordinal();
 
             public final String name;
 
@@ -526,7 +526,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
             Absent("absent"),
             Unknown("unknown");
 
-            //public static final Integer length = 1 + Absent.ordinal();
+            // public static final Integer length = 1 + Absent.ordinal();
 
             public final String name;
 
@@ -1236,7 +1236,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
         protected AttributedLaunchData(@Nullable final Uri shortLink, @NonNull Uri deepLink) {
             super(shortLink);
 
-            if(deepLink.isOpaque()) {
+            if (deepLink.isOpaque()) {
                 this.scheduleName = this.scheduleId = this.creativeName = this.creativeId = this.rewardId = this.channelName = this.optOutCategory = null;
                 this.deepLink = deepLink;
                 return;
@@ -1276,7 +1276,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
             this.rewardId = Helpers.newIfNotOld(oldLaunchData.rewardId, newLaunchData.rewardId);
             this.channelName = Helpers.newIfNotOld(oldLaunchData.channelName, newLaunchData.channelName);
             this.deepLink = updatedDeepLink;
-            if(updatedDeepLink.isHierarchical()) {
+            if (updatedDeepLink.isHierarchical()) {
                 this.optOutCategory = Helpers.newIfNotOld(oldLaunchData.optOutCategory,
                     updatedDeepLink.getQueryParameter("teak_opt_out_category") != null ? updatedDeepLink.getQueryParameter("teak_opt_out_category") : "teak");
             } else {
@@ -1302,7 +1302,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
             // Put the URI and any query parameters that start with 'teak_' into 'deep_link'
             if (this.deepLink != null) {
                 map.put("deep_link", this.deepLink.toString());
-                if(this.deepLink.isHierarchical()) {
+                if (this.deepLink.isHierarchical()) {
                     for (final String name : this.deepLink.getQueryParameterNames()) {
                         if (name.startsWith("teak_")) {
                             final List<String> values = this.deepLink.getQueryParameters(name);
@@ -1376,7 +1376,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
          */
         protected NotificationLaunchData(@NonNull final NotificationLaunchData oldLaunchData, @NonNull Uri updatedDeepLink) {
             super(oldLaunchData, updatedDeepLink);
-            if(updatedDeepLink.isHierarchical()) {
+            if (updatedDeepLink.isHierarchical()) {
                 this.sourceSendId = Helpers.newIfNotOld(oldLaunchData.sourceSendId, updatedDeepLink.getQueryParameter("teak_notif_id"));
             } else {
                 this.sourceSendId = oldLaunchData.sourceSendId;
@@ -1506,7 +1506,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
         public JSONObject toJSON() {
             final JSONObject json = new JSONObject();
             final ArrayList<JSONObject> categories = new ArrayList<JSONObject>();
-            for(Teak.Channel.Category category : this.remoteConfiguration.categories) {
+            for (Teak.Channel.Category category : this.remoteConfiguration.categories) {
                 categories.add(category.toJSON());
             }
 

--- a/src/main/java/io/teak/sdk/TeakNotification.java
+++ b/src/main/java/io/teak/sdk/TeakNotification.java
@@ -286,7 +286,7 @@ public class TeakNotification implements Unobfuscable {
 
                 try {
                     // https://rewards.gocarrot.com/<<teak_reward_id>>/clicks?clicking_user_id=<<your_user_id>>
-                    //String requestBody = "clicking_user_id=" + URLEncoder.encode(session.userId(), "UTF-8");
+                    // String requestBody = "clicking_user_id=" + URLEncoder.encode(session.userId(), "UTF-8");
                     HashMap<String, Object> payload = new HashMap<>();
                     payload.put("clicking_user_id", session.userId());
 

--- a/src/main/java/io/teak/sdk/core/DeviceScreenState.java
+++ b/src/main/java/io/teak/sdk/core/DeviceScreenState.java
@@ -32,7 +32,7 @@ public class DeviceScreenState {
         ScreenOn("ScreenOn"),
         ScreenOff("ScreenOff");
 
-        //public static final Integer length = 1 + Expired.ordinal();
+        // public static final Integer length = 1 + Expired.ordinal();
 
         private static final State[][] allowedTransitions = {
             {State.ScreenOn, State.ScreenOff},

--- a/src/main/java/io/teak/sdk/core/Session.java
+++ b/src/main/java/io/teak/sdk/core/Session.java
@@ -66,7 +66,7 @@ public class Session {
         Expiring("Expiring"),
         Expired("Expired");
 
-        //public static final Integer length = 1 + Expired.ordinal();
+        // public static final Integer length = 1 + Expired.ordinal();
 
         private static final State[][] allowedTransitions = {
             {},
@@ -294,7 +294,7 @@ public class Session {
                         TeakCore.operationQueue.execute(this.userProfile);
                     }
 
-                    if(this.serverSessionId != null) {
+                    if (this.serverSessionId != null) {
                         this.sessionVectorClock++;
                         // This is a message to the server that, in effect, says "If you don't hear
                         // from me again, consider this session over"
@@ -334,7 +334,7 @@ public class Session {
             TeakEvent.postEvent(new SessionStateEvent(this, this.state, this.previousState));
 
             TeakConfiguration teakConfiguration = TeakConfiguration.get();
-            //noinspection all - Seriously, that is not a simplification
+            // noinspection all - Seriously, that is not a simplification
             if (this.state == State.Created && teakConfiguration != null && teakConfiguration.remoteConfiguration != null) {
                 return setState(State.Configured);
             } else {
@@ -355,7 +355,7 @@ public class Session {
         }
 
         // TODO: Revist this when we have time, if it is important
-        //noinspection deprecation - Alex said "ehhhhhhh" to changing the heartbeat param to a map
+        // noinspection deprecation - Alex said "ehhhhhhh" to changing the heartbeat param to a map
         @SuppressWarnings("deprecation")
         final String teakSdkVersion = Teak.SDKVersion;
 
@@ -722,7 +722,7 @@ public class Session {
                     }
                     break;
                 case LifecycleEvent.Resumed:
-                    LifecycleEvent lEvent = (LifecycleEvent)event;
+                    LifecycleEvent lEvent = (LifecycleEvent) event;
                     onActivityResumed(lEvent.intent, lEvent.context);
                     break;
             }
@@ -939,7 +939,7 @@ public class Session {
     private void forceExpire() {
         stateLock.lock();
         try {
-            if(state != State.Expired) {
+            if (state != State.Expired) {
                 setState(State.Expiring);
                 setState(State.Expired);
             }
@@ -988,7 +988,7 @@ public class Session {
             } else if (launchDataSource != LaunchDataSource.Unattributed) {
                 Session oldSession = currentSession;
                 currentSession = new Session(oldSession, launchDataSource);
-                if(oldSession != null) {
+                if (oldSession != null) {
                     oldSession.forceExpire();
                 }
             } else {

--- a/src/main/java/io/teak/sdk/io/DefaultAndroidDeviceInfo.java
+++ b/src/main/java/io/teak/sdk/io/DefaultAndroidDeviceInfo.java
@@ -260,23 +260,23 @@ public class DefaultAndroidDeviceInfo implements IAndroidDeviceInfo {
      */
     @Override
     public int getNumCores() {
-        //Private Class to display only CPU devices in the directory listing
+        // Private Class to display only CPU devices in the directory listing
         class CpuFilter implements FileFilter {
             @Override
             public boolean accept(File pathname) {
-                //Check if filename is "cpu", followed by a single digit number
+                // Check if filename is "cpu", followed by a single digit number
                 return Pattern.matches("cpu[0-9]+", pathname.getName());
             }
         }
 
         try {
-            //Get directory containing CPU info
+            // Get directory containing CPU info
             File dir = new File("/sys/devices/system/cpu/");
 
-            //Filter to only list the devices we care about
+            // Filter to only list the devices we care about
             File[] files = dir.listFiles(new CpuFilter());
 
-            //Return the number of cores (virtual CPU devices)
+            // Return the number of cores (virtual CPU devices)
             return files.length;
         } catch (Exception e) {
             Teak.log.exception(e);

--- a/src/main/java/io/teak/sdk/io/DefaultAndroidNotification.java
+++ b/src/main/java/io/teak/sdk/io/DefaultAndroidNotification.java
@@ -135,11 +135,11 @@ public class DefaultAndroidNotification implements IAndroidNotification {
         // return the summary notification, which breaks our downstream logic.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             StatusBarNotification[] notifications = notificationManager.getActiveNotifications();
-            if(notifications != null) {
-                for(StatusBarNotification sbn : notifications) {
+            if (notifications != null) {
+                for (StatusBarNotification sbn : notifications) {
                     final Notification notification = sbn.getNotification();
-                    if(Objects.equals(groupKey, NotificationCompat.getGroup(notification))) {
-                        if(NotificationCompat.isGroupSummary(notification)) {
+                    if (Objects.equals(groupKey, NotificationCompat.getGroup(notification))) {
+                        if (NotificationCompat.isGroupSummary(notification)) {
                             summary = sbn;
                         } else {
                             children.add(sbn);
@@ -154,7 +154,7 @@ public class DefaultAndroidNotification implements IAndroidNotification {
         Arrays.sort(childrenArr, (a, b) -> {
             long diff = b.getNotification().when - a.getNotification().when;
             // Bit of absurdity to deal with converting long to int.
-            if(diff < 0) {
+            if (diff < 0) {
                 return -1;
             } else if (diff == 0) {
                 return 0;
@@ -172,7 +172,7 @@ public class DefaultAndroidNotification implements IAndroidNotification {
 
         this.notificationManager.cancel(NOTIFICATION_TAG, platformId);
 
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && groupKey != null) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && groupKey != null) {
             final NotificationGroup groupInfo = DefaultAndroidNotification.this.getActiveNotificationsForGroup(groupKey);
 
             final StatusBarNotification groupSummary = groupInfo.summary;
@@ -181,25 +181,23 @@ public class DefaultAndroidNotification implements IAndroidNotification {
             // out, that was not the issue, but at this point I don't trust Android so I'm going to leave this
             // check in, in case there are devices where getting active notifications immediately after cancelling
             // one still returns the cancelled one.
-            for(StatusBarNotification sbn : groupInfo.children) {
-                if(sbn.getId() != platformId) {
+            for (StatusBarNotification sbn : groupInfo.children) {
+                if (sbn.getId() != platformId) {
                     ourNotifications.add(sbn.getNotification());
                 }
             }
 
             Teak.log.i(
                 "default_android_notification.cancel_notification.summary_info",
-                Helpers.mm.h("liveCount", ourNotifications.size(), "hasSummary", groupSummary != null)
-            );
+                Helpers.mm.h("liveCount", ourNotifications.size(), "hasSummary", groupSummary != null));
 
-            if(groupSummary != null && ourNotifications.size() > 0) {
+            if (groupSummary != null && ourNotifications.size() > 0) {
                 this.handler.post(() -> {
                     try {
                         DefaultAndroidNotification.this.notificationManager.notify(
                             NOTIFICATION_TAG,
                             groupSummary.getId(),
-                            NotificationBuilder.createSummaryNotification(context, groupKey, ourNotifications)
-                        );
+                            NotificationBuilder.createSummaryNotification(context, groupKey, ourNotifications));
                     } catch (SecurityException ignored) {
                         // This likely means that they need the VIBRATE permission on old versions of Android
                         Teak.log.e("notification.permission_needed.vibrate", "Please add this to your AndroidManifest.xml: <uses-permission android:name=\"android.permission.VIBRATE\" />");
@@ -209,9 +207,8 @@ public class DefaultAndroidNotification implements IAndroidNotification {
                         Teak.log.exception(e);
                         throw e;
                     }
-
                 });
-            } else if(groupSummary != null && ourNotifications.size() == 0) {
+            } else if (groupSummary != null && ourNotifications.size() == 0) {
                 // This came up in the Android 7.1 test -- if the group summary was not explicitly cancelled then
                 // it would show up as a notification using the inbox style and already issued intents so it
                 // couldn't launch the game.
@@ -259,20 +256,20 @@ public class DefaultAndroidNotification implements IAndroidNotification {
 
                 final String groupKey = NotificationCompat.getGroup(nativeNotification);
 
-                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && groupKey != null) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && groupKey != null) {
                     final NotificationGroup groupInfo = DefaultAndroidNotification.this.getActiveNotificationsForGroup(groupKey);
 
                     final StatusBarNotification groupSummary = groupInfo.summary;
                     final StatusBarNotification[] extantNotifications = groupInfo.children;
                     final ArrayList<Notification> ourNotifications = new ArrayList<Notification>();
                     boolean listNeedsUs = true;
-                    for(StatusBarNotification n : extantNotifications) {
-                        if(n.getId() == platformId) {
+                    for (StatusBarNotification n : extantNotifications) {
+                        if (n.getId() == platformId) {
                             listNeedsUs = false;
                         }
                         ourNotifications.add(n.getNotification());
                     }
-                    if(listNeedsUs) {
+                    if (listNeedsUs) {
                         ourNotifications.add(0, nativeNotification);
                     }
 
@@ -280,20 +277,18 @@ public class DefaultAndroidNotification implements IAndroidNotification {
 
                     Teak.log.i(
                         "default_android_notification.display_notification.summary_info",
-                        Helpers.mm.h("liveCount", notificationCount, "hasSummary", groupSummary != null)
-                    );
+                        Helpers.mm.h("liveCount", notificationCount, "hasSummary", groupSummary != null));
 
-                    if(notificationCount >= teakNotification.minGroupSize) {
+                    if (notificationCount >= teakNotification.minGroupSize) {
                         int summaryId = teakNotification.groupSummaryId;
-                        if(groupSummary != null) {
+                        if (groupSummary != null) {
                             summaryId = groupSummary.getId();
                         }
 
                         DefaultAndroidNotification.this.notificationManager.notify(
                             NOTIFICATION_TAG,
                             summaryId,
-                            NotificationBuilder.createSummaryNotification(context, groupKey, ourNotifications)
-                        );
+                            NotificationBuilder.createSummaryNotification(context, groupKey, ourNotifications));
                     }
                 }
 

--- a/src/main/java/io/teak/sdk/push/FCMPushProvider.java
+++ b/src/main/java/io/teak/sdk/push/FCMPushProvider.java
@@ -229,8 +229,8 @@ public class FCMPushProvider extends FirebaseMessagingService implements IPushPr
         }
         final String msg = e.getMessage();
         return msg != null && (msg.equals("SERVICE_NOT_AVAILABLE") ||
-                               msg.equals("MISSING_INSTANCEID_SERVICE") ||
-                               msg.equals("FIS_AUTH_ERROR"));
+                                  msg.equals("MISSING_INSTANCEID_SERVICE") ||
+                                  msg.equals("FIS_AUTH_ERROR"));
     }
 
     ///// Beware of the Leopard

--- a/src/main/java/io/teak/sdk/push/PushState.java
+++ b/src/main/java/io/teak/sdk/push/PushState.java
@@ -34,7 +34,7 @@ public class PushState implements Unobfuscable {
         Authorized("authorized"),
         Denied("denied");
 
-        //public static final Integer length = 1 + Denied.ordinal();
+        // public static final Integer length = 1 + Denied.ordinal();
 
         private static final State[][] allowedTransitions = {
             {State.Authorized, State.Denied},

--- a/src/main/java/io/teak/sdk/raven/Raven.java
+++ b/src/main/java/io/teak/sdk/raven/Raven.java
@@ -505,9 +505,7 @@ public class Raven implements Thread.UncaughtExceptionHandler {
             // Observability: how many breadcrumbs survived size-budgeting and the resulting
             // payload size. Fires once per exception report (rare); trimming is normal operation,
             // hence debug, not warn/error.
-            Log.d(LOG_TAG, "Sentry report: " + fitted.size() + " of " + this.breadcrumbSnapshot.size()
-                               + " breadcrumbs kept, payload " + payloadJson.getBytes(StandardCharsets.UTF_8).length
-                               + " bytes (size budget " + PAYLOAD_BUDGET_BYTES + ").");
+            Log.d(LOG_TAG, "Sentry report: " + fitted.size() + " of " + this.breadcrumbSnapshot.size() + " breadcrumbs kept, payload " + payloadJson.getBytes(StandardCharsets.UTF_8).length + " bytes (size budget " + PAYLOAD_BUDGET_BYTES + ").");
 
             Data data = this.buildData(payloadJson);
             if (data != null) {

--- a/src/main/java/io/teak/sdk/store/GooglePlayBillingV5.java
+++ b/src/main/java/io/teak/sdk/store/GooglePlayBillingV5.java
@@ -63,9 +63,9 @@ public class GooglePlayBillingV5 implements Unobfuscable, IStore, PurchasesUpdat
                     final QueryProductDetailsParams params = QueryProductDetailsParams
                                                                  .newBuilder()
                                                                  .setProductList(Collections.singletonList(QueryProductDetailsParams.Product.newBuilder()
-                                                                                                               .setProductId(purchaseSku)
-                                                                                                               .setProductType(BillingClient.ProductType.SUBS)
-                                                                                                               .build()))
+                                                                         .setProductId(purchaseSku)
+                                                                         .setProductType(BillingClient.ProductType.SUBS)
+                                                                         .build()))
                                                                  .build();
 
                     this.billingClient.queryProductDetailsAsync(params, (ignored, productDetailsList) -> {

--- a/validate-code-format
+++ b/validate-code-format
@@ -14,8 +14,15 @@
 
 ##################################################################
 # SETTINGS
-# set path to clang-format binary
-CLANG_FORMAT="/usr/local/bin/clang-format"
+# locate the clang-format binary: prefer whatever's on PATH, fall back to
+# the Homebrew prefix (covers both Apple Silicon /opt/homebrew and Intel
+# /usr/local without hardcoding either).
+# Baseline verified against clang-format 21.1.8 -- a different version can
+# produce spurious diffs on otherwise-conformant files.
+CLANG_FORMAT="$(command -v clang-format || true)"
+if [ -z "$CLANG_FORMAT" ] && command -v brew >/dev/null 2>&1; then
+    CLANG_FORMAT="$(brew --prefix clang-format 2>/dev/null)/bin/clang-format"
+fi
 
 # remove any older patches from previous commits. Set to true or false.
 # DELETE_OLD_PATCHES=false
@@ -29,7 +36,10 @@ PARSE_EXTS=true
 
 # file types to parse. Only effective when PARSE_EXTS is true.
 # FILE_EXTS=".c .h .cpp .hpp"
-FILE_EXTS=".c .h .cpp .hpp .cc .hh .cxx .m"
+FILE_EXTS=".c .h .cpp .hpp .cc .hh .cxx .m .java"
+
+# vendored paths excluded from formatting/validation (mirrors format-code's prune list)
+VENDORED_PATHS="src/main/java/io/teak/sdk/shortcutbadger src/main/java/io/teak/sdk/json"
 
 ##################################################################
 # There should be no need to change anything below this line.
@@ -79,6 +89,20 @@ matches_extension() {
     return 1
 }
 
+# check whether the given file lives under a vendored path excluded from formatting
+is_vendored_path() {
+    local filename="$1"
+    local vendored
+
+    for vendored in $VENDORED_PATHS; do
+        case "$filename" in
+            "$vendored"/*) return 0 ;;
+        esac
+    done
+
+    return 1
+}
+
 # necessary check for initial commit
 if git rev-parse --verify HEAD >/dev/null 2>&1 ; then
     against=HEAD
@@ -107,6 +131,10 @@ do
     # ignore file if we do check for file extensions and the file
     # does not match any of the extensions specified in $FILE_EXTS
     if $PARSE_EXTS && ! matches_extension "$file"; then
+        continue;
+    fi
+
+    if is_vendored_path "$file"; then
         continue;
     fi
 


### PR DESCRIPTION
Closes two formatting-tooling gaps that cost workers junk diffs and unenforced Java style this milestone:

1. `format-code` only pruned `shortcutbadger/`, so it reformatted vendored `json/` under whatever local clang-format version a dev had — a large unrelated diff to hand-revert. Now mirrors the prune for `json/`.
2. `validate-code-format`'s `FILE_EXTS` omitted `.java`, so the pre-commit hook never actually gated Java style. Added `.java`, mirrored the vendored-path exclusion, and replaced the hardcoded `/usr/local/bin/clang-format` path (broken on Apple Silicon) with `which`-based detection.

Enabling the `.java` gate exposed that 11 of 79 non-vendored files weren't actually clang-format-conformant (mostly `if(`/`for(` spacing). Reformatted those in a separate commit — pure `clang-format -style=file` output via the repo's `.clang-format` config, clang-format 21.1.8. `test_app`'s full unit suite (91 tests) and `./gradlew assemble` both pass unchanged after the reformat.

No pinned-version infra exists anywhere in the SDK suite (checked teak-ios too), so per discussion with the lead, the "pin the version" ask from the issue is answered by recording the tested baseline (21.1.8) in the script comment + `CLAUDE.md`, not by building version-pinning machinery — out of scope for a dev-tooling ticket.

Also corrected a `CLAUDE.md` inaccuracy found along the way: `validate-code-format` was listed under "CI Checks" but CI never runs it — confirmed via `.circleci/config.yml`. It's local pre-commit-hook only, which is the actual enforcement gap this issue describes.

Dev tooling only, no user-facing SDK behavior change — no changelog entry.

https://linear.app/teakio/issue/C-835