### PR TITLE
Emit observable log event on uncaught exceptions

### DIFF
--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,3 +1,6 @@
+enhancement:
+  - Uncaught exceptions now emit an observable `exception` log event (visible to a `LogListener`), matching the caught-exception path.
+
 bug:
   - FCM registration no longer omits the sender ID when the framework delivers the first push token on a fresh install.
   - No longer select the FCM push provider on devices that have no Google Play Services installed (e.g. Amazon Fire), where requesting a push token would fail with `MISSING_INSTANCEID_SERVICE`. ADM is still preferred on Amazon, and Google devices that merely need a Play Services update keep FCM.

--- a/src/main/java/io/teak/sdk/raven/Raven.java
+++ b/src/main/java/io/teak/sdk/raven/Raven.java
@@ -201,6 +201,13 @@ public class Raven implements Thread.UncaughtExceptionHandler {
     @Override
     public void uncaughtException(@NonNull Thread thread, @NonNull Throwable ex) {
         if (!(ex instanceof OutOfMemoryError)) {
+            // Emit the observable log event for parity with the caught path (Log.exception).
+            // reportToRaven=false: this handler reports to Sentry itself on the next line, so the
+            // false avoids a duplicate report through the SDK Raven. Signal-prefixed throwables are
+            // skipped here exactly as reportException skips them, so a native crash emits no event.
+            if (!Raven.shouldSuppressThrowable(ex)) {
+                Teak.log.exception(ex, false);
+            }
             reportException(ex, null);
         }
     }

--- a/test_app/app/src/test/java/io/teak/app/test/UncaughtExceptionLogEventTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/UncaughtExceptionLogEventTest.java
@@ -1,0 +1,96 @@
+package io.teak.app.test;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.teak.sdk.Teak;
+import io.teak.sdk.TeakConfiguration;
+import io.teak.sdk.raven.Raven;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+// The uncaught-exception handler (Raven, registered as the default uncaught handler) emits the same
+// observable log event the caught path emits via Log.exception: event_type "exception", level ERROR,
+// event_data {type, value}. Native-crash markers (signal-prefixed) and OutOfMemoryError stay
+// Sentry-only and emit no event. These drive raven.uncaughtException(thread, ex) against the real
+// handler, so they fail if the emit is reverted, and they positively prove the event fires (not just
+// the absence of a crash).
+@RunWith(MockitoJUnitRunner.class)
+public class UncaughtExceptionLogEventTest extends TeakUnitTest {
+
+    // The LogListener receives the full event payload, which carries event_type/log_level/event_data.
+    private final List<Map<String, Object>> events = new ArrayList<>();
+
+    private Raven makeRaven() {
+        return new Raven(context, "sdk", TeakConfiguration.get(), objectFactory);
+    }
+
+    // Capture every emitted log event, then flip Log to drain immediately (no DSN/Raven needed).
+    private void captureLogEvents() {
+        Teak.log.setLogListener(new Teak.LogListener() {
+            @Override
+            public void logEvent(String logEvent, String logLevel, Map<String, Object> logData) {
+                events.add(logData);
+            }
+        });
+        Teak.log.markConfigurationReady();
+    }
+
+    private Map<String, Object> firstExceptionEvent() {
+        for (Map<String, Object> event : events) {
+            if ("exception".equals(event.get("event_type"))) {
+                return event;
+            }
+        }
+        return null;
+    }
+
+    @After
+    public void tearDown() {
+        Teak.log.setLogListener(null);
+        Teak.log.setSdkRaven(null);
+    }
+
+    @Test
+    public void uncaughtExceptionEmitsObservableLogEvent() {
+        captureLogEvents();
+
+        makeRaven().uncaughtException(Thread.currentThread(), new RuntimeException("boom"));
+
+        final Map<String, Object> event = firstExceptionEvent();
+        assertNotNull("uncaught exception must emit an \"exception\" log event", event);
+        assertEquals("ERROR", event.get("log_level"));
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> data = (Map<String, Object>) event.get("event_data");
+        assertNotNull("event must carry event_data", data);
+        assertEquals("RuntimeException", data.get("type"));
+        assertEquals("boom", data.get("value"));
+    }
+
+    @Test
+    public void signalPrefixedThrowableEmitsNoLogEvent() {
+        captureLogEvents();
+
+        makeRaven().uncaughtException(Thread.currentThread(), new RuntimeException("signal 11 (SIGSEGV)"));
+
+        assertNull("signal-prefixed native crash must emit no log event", firstExceptionEvent());
+    }
+
+    @Test
+    public void outOfMemoryErrorEmitsNoLogEvent() {
+        captureLogEvents();
+
+        makeRaven().uncaughtException(Thread.currentThread(), new OutOfMemoryError("oom"));
+
+        assertNull("OutOfMemoryError must emit no log event", firstExceptionEvent());
+    }
+}


### PR DESCRIPTION
Resolves C-844 — https://linear.app/teakio/issue/C-844

## What
Uncaught exceptions now emit the same observable `exception` log event the caught path already emits, so a host-app `LogListener` sees uncaught crashes the same way it sees caught ones. Follow-up to C-843 (iOS caught-path parity), which deliberately deferred the uncaught path.

## How
`Raven.uncaughtException` adds one call to the caught-path emit, `Teak.log.exception(ex, false)`:
- **Shape is identical to caught** — it reuses `throwableToMap`, producing `event_type "exception"`, level `ERROR`, `event_data {type, value, module, stacktrace}`. So Android stays internally consistent caught == uncaught.
- **`reportToRaven=false`** — the handler already reports to Sentry on the next line; `false` avoids a duplicate report through the SDK Raven. `reportToRaven` gates only the Sentry send, not the `log()` call.
- **Suppressions preserved** — the emit is gated on `!shouldSuppressThrowable(ex)` and stays inside the existing `OutOfMemoryError` guard, so signal-prefixed native crashes and OOM remain Sentry-only and emit no event.

## Cross-platform contract
The cross-platform guarantee is the `{type, value}` intersection. `module`/`stacktrace` are Android-only extras (iOS has neither) — already true on the caught path. The C-739 e2e must assert `{type, value}` only.

## Tests
`UncaughtExceptionLogEventTest` drives `raven.uncaughtException(thread, ex)` against the real handler:
- positively asserts the `LogListener` receives the event with `{type, value}` (fails if the emit is reverted — verified)
- signal-prefixed throwable → no event
- `OutOfMemoryError` → no event

Full debug suite: 94 tests, 0 failures.
