### PR TITLE
Sync develop docs into 4.3-stable

### DIFF
--- a/MIN_VERSIONS.yml
+++ b/MIN_VERSIONS.yml
@@ -1,0 +1,5 @@
+# Minimum version requirements for the Teak Android SDK.
+# Read by antora-ui-teak/script/extract-sdk-versions at docs build time.
+# Update this file when minimum versions change.
+min-android-sdk: "21"
+min-android-name: "5.0"

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -11,5 +11,3 @@ asciidoc:
     table-caption: false
     caution-caption: Deprecated@
     source-language: java@
-    min-android-name: '5'
-    min-android-sdk: '21'

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -11,3 +11,5 @@ asciidoc:
     table-caption: false
     caution-caption: Deprecated@
     source-language: java@
+    min-android-name: '5'
+    min-android-sdk: '21'

--- a/docs/modules/ROOT/pages/integration.adoc
+++ b/docs/modules/ROOT/pages/integration.adoc
@@ -193,6 +193,7 @@ public class MainActivity extends AppCompatActivity {
 
         // Register with EventBus
         EventBus.getDefault().register(this);
+    }
 }
 ----
 

--- a/docs/modules/ROOT/pages/integration.adoc
+++ b/docs/modules/ROOT/pages/integration.adoc
@@ -1,5 +1,9 @@
 = Integration
 
+== Requirements
+
+* [x] Android {min-android-name} (API level {min-android-sdk}) or newer
+
 The latest version of the Teak Android SDK is always available at:
 
 * http://sdks.teakcdn.com/android/teak.aar
@@ -170,25 +174,67 @@ This tells Android to look for deep link URLs created by Teak.
 
 Teak uses https://github.com/greenrobot/EventBus[EventBus] to send events to your game.
 
+=== Register an object to handle events
+
+You can register any object to handle events posted by Teak. A quick way to get started would be to register your main activity as a handler, like so:
+
+.Registering an event handler
+[source,java]
+----
+import androidx.appcompat.app.AppCompatActivity;
+
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+
+public class MainActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // Register with EventBus
+        EventBus.getDefault().register(this);
+}
+----
+
+To receive events, declare methods with the `@Subscribe` annotation which take the type of event that method should handle. We'll show some examples below.
+
 === Events
 
 <<Teak.NotificationEvent>>:: A notification has been received.
 
-<<Teak.RewardClaimEvent>>:: A reward claim has happened.
+<<Teak.RewardClaimEvent>>:: A reward claim has been processed.
 
 <<Teak.LaunchFromLinkEvent>>:: The app was launched from a URL created on the Teak dashboard.
 
 <<Teak.UserDataEvent>>:: Data about the user has become available, or has been updated.
 
-.Subscribing to an event
+.Handling a Reward Claim
 [source,java]
 ----
 @Subscribe
-public void onNotification(Teak.NotificationEvent event) {
-  if (event.isForeground) {
-    // A notification was received while the game was in the foreground
-  } else {
-    // The game was launched via this notification
+public void onRewardClaim(Teak.RewardClaimEvent event) {
+  TeakNotification.Reward rewardInfo = event.reward;
+  String rewardId = rewardInfo.json.getString("teakRewardId");
+  switch(rewardInfo.status) {
+    case TeakNotification.Reward.GRANT_REWARD: {
+      Map<String, Object> reward = rewardInfo.json.getJSONObject("reward").toMap();
+      Log.d("TeakExample.Reward", "Reward with id " + rewardId + "Granted! " + reward.toString());
+    } break;
+    case TeakNotification.Reward.ALREADY_CLICKED: {
+      Log.d("TeakExample.Reward", "You already claimed this reward!");
+    } break;
+    case TeakNotification.Reward.EXPIRED: {
+      Log.d("TeakExample.Reward", "The reward has expired");
+    } break;
+    case TeakNotification.Reward.TOO_MANY_CLICKS: {
+      Log.d("TeakExample.Reward", "Too many other players already claimed this reward");
+    } break;
+    case TeakNotification.Reward.EXCEED_MAX_CLICKS_FOR_DAY: {
+      Log.d("TeakExample.Reward", "You've already claimed too many rewards today");
+    } break;
+    default: {
+      Log.d("TeakExample.Reward", "The reward was rejected for a different reason: " + rewardInfo.json.getString("status"));
+    }
   }
 }
 ----

--- a/docs/modules/ROOT/partials/nav-android.adoc
+++ b/docs/modules/ROOT/partials/nav-android.adoc
@@ -1,0 +1,8 @@
+** xref:android::page$integration.adoc[Android Native SDK]
+*** xref:android::page$integration.adoc[Integration]
+*** xref:android::page$working-with-teak.adoc[Working With Teak]
+*** xref:android::page$notification-icon.adoc[Notification Icons]
+*** xref:android::page$sdk5.adoc[SDK5 Preview]
+*** xref:android::page$android-12.adoc[Android 12]
+*** xref:android::page$third-party.adoc[Third-Party Code]
+*** xref:android:changelog:page$changelog.adoc[Changelog]

--- a/docs/modules/changelog/versions/4.3.9.yaml
+++ b/docs/modules/changelog/versions/4.3.9.yaml
@@ -1,0 +1,4 @@
+bug:
+  - Resolved issue where a single notification could create a notification group
+  - Resolved issue with customizing notification group minimum size from server
+  - Resolved issue with customizing notification group id from server


### PR DESCRIPTION
[sdks-teak-android-worker-c-928]

Brings develop's `docs/` nav structure and content into `4.3-stable` so the maintenance doc site matches develop. Part of the fix for the flat-navbar divergence surfaced reviewing the C-925 preview. **Docs-only.**

Linear: https://linear.app/teakio/issue/C-928

### What's synced
The `docs/` diff between the branches is 4 files; the changelog module diverges by design, so this is a surgical per-file sync (not a wholesale snapshot). One repo-root file (`MIN_VERSIONS.yml`) is also synced — see below.

| File | Action | Why |
|------|--------|-----|
| `partials/nav-android.adoc` (new) | **sync** | The nested nav partial teak-usage's unified nav is meant to consume. All 8 xrefs verified to resolve on 4.3-stable. |
| `pages/integration.adoc` | **sync + fix** | Adds a Requirements section, an EventBus-registration example, and a RewardClaimEvent handler example. One develop-inherited defect fixed in-PR: the EventBus snippet never closed the `MainActivity` class body (2 open braces / 1 close) — class now closed. |
| `MIN_VERSIONS.yml` (new, repo root) | **sync** | Root file (byte-identical to develop) read by `antora-ui-teak/script/extract-sdk-versions`, which injects `min-android-name`/`min-android-sdk` as Antora attributes. 4.3-stable was missing it, so the new Requirements bullet rendered literal placeholders. |
| `changelog/versions/4.3.9.yaml` (new) | **sync** | Fills a real gap — 4.3-stable's history skipped 4.3.8 → 4.3.10. |
| `changelog/unreleased.yaml` | **excluded** | develop's is empty; 4.3-stable's holds the pending 4.3.x entries (C-844/C-862/C-899/C-367) bound for the 4.3.14 release notes. Syncing would wipe them. |

### Requirements bullet — verified end-to-end
`{min-android-name}`/`{min-android-sdk}` are injected at build time from the root `MIN_VERSIONS.yml` (not hardcoded). Confirmed against develop's live production render **and** an isolated build through the exact CI arg path — both produce **"Android 5.0 (API level 21) or newer"**.

### Nav wiring is a prerequisite, not a complete fix
`nav-android.adoc` is currently **not consumed** by teak-usage's unified nav (its `include::android::partial$nav-android.adoc[]` is commented out). Shipping the partial here is the necessary **prerequisite** so that once teak-usage wires it in (tracked separately as C-934), 4.3-stable's maint site renders the nested Android nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)