### PR TITLE
Add 4.3.14 changelog

### DIFF
--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,7 +1,0 @@
-enhancement:
-  - Uncaught exceptions now emit an observable `exception` log event (visible to a `LogListener`), matching the caught-exception path.
-
-bug:
-  - FCM registration no longer omits the sender ID when the framework delivers the first push token on a fresh install.
-  - No longer select the FCM push provider on devices that have no Google Play Services installed (e.g. Amazon Fire), where requesting a push token would fail with `MISSING_INSTANCEID_SERVICE`. ADM is still preferred on Amazon, and Google devices that merely need a Play Services update keep FCM.
-  - A missing or invalid Firebase configuration now raises an integration error only when push is in use; apps that intentionally ship no push (`io_teak_enable_push_key=false`) no longer see a spurious error, and the message now points at that opt-out.

--- a/docs/modules/changelog/versions/4.3.14.yaml
+++ b/docs/modules/changelog/versions/4.3.14.yaml
@@ -1,0 +1,6 @@
+enhancement:
+  - "Uncaught exceptions now emit an `exception` log event to registered log listeners."
+bug:
+  - "FCM registration no longer omits the sender ID on the first push token after a fresh install."
+  - "The FCM push provider is no longer selected on devices without Google Play Services (e.g. Amazon Fire); ADM remains preferred on Amazon."
+  - "A missing or invalid Firebase configuration now raises an integration error only when push is in use, not for apps that intentionally ship without push."


### PR DESCRIPTION
4.3.14 release notes. Migrates the accumulated `unreleased.yaml` entries into `versions/4.3.14.yaml` with a simplification pass, and resets `unreleased.yaml`.

**enhancement:** uncaught-exception log event
**bug:** FCM sender-id on first token, FCM-not-selected without Play Services (ADM-preferred on Amazon), Firebase-config error only when push in use.

Simplified per the same integrator-voice pass as the iOS changelog — cut internal error codes / opt-out-key detail, kept symptom+fix.

[sdks-lead-pm]