### PR TITLE
Guard uncaught-path exception emit against a throwing host LogListener

### DIFF
--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,0 +1,2 @@
+bug:
+  - "A host `LogListener` that throws during an uncaught exception no longer suppresses the Sentry crash report."

--- a/src/main/java/io/teak/sdk/raven/Raven.java
+++ b/src/main/java/io/teak/sdk/raven/Raven.java
@@ -205,8 +205,14 @@ public class Raven implements Thread.UncaughtExceptionHandler {
             // reportToRaven=false: this handler reports to Sentry itself on the next line, so the
             // false avoids a duplicate report through the SDK Raven. Signal-prefixed throwables are
             // skipped here exactly as reportException skips them, so a native crash emits no event.
+            // Guarded because this is the last-resort handler: the synchronous host LogListener is
+            // the only host code on this path, so a throwing listener would escape and suppress the
+            // Sentry crash report below. Swallow it -- don't re-log, the log system is what threw.
             if (!Raven.shouldSuppressThrowable(ex)) {
-                Teak.log.exception(ex, false);
+                try {
+                    Teak.log.exception(ex, false);
+                } catch (Throwable ignored) {
+                }
             }
             reportException(ex, null);
         }

--- a/test_app/app/src/test/java/io/teak/app/test/UncaughtExceptionLogEventTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/UncaughtExceptionLogEventTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -92,5 +93,32 @@ public class UncaughtExceptionLogEventTest extends TeakUnitTest {
         makeRaven().uncaughtException(Thread.currentThread(), new OutOfMemoryError("oom"));
 
         assertNull("OutOfMemoryError must emit no log event", firstExceptionEvent());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Object> queuedReports(Raven raven) throws Exception {
+        Field field = Raven.class.getDeclaredField("queuedReports");
+        field.setAccessible(true);
+        return (List<Object>) field.get(raven);
+    }
+
+    // This is the last-resort handler: a throwing host LogListener must not escape
+    // uncaughtException and suppress the Sentry report. Proves the positive -- that
+    // reportException still ran and queued a report -- not just that no exception escaped.
+    @Test
+    public void uncaughtExceptionStillReportsWhenLogListenerThrows() throws Exception {
+        Teak.log.setLogListener(new Teak.LogListener() {
+            @Override
+            public void logEvent(String logEvent, String logLevel, Map<String, Object> logData) {
+                throw new RuntimeException("listener boom");
+            }
+        });
+        Teak.log.markConfigurationReady();
+
+        Raven raven = makeRaven();
+        raven.uncaughtException(Thread.currentThread(), new RuntimeException("boom"));
+
+        assertEquals("reportException must still queue a Sentry report despite the throwing listener",
+            1, queuedReports(raven).size());
     }
 }


### PR DESCRIPTION
Linear: https://linear.app/teakio/issue/994

## Summary
- `Raven.uncaughtException` emitted the observable log event via `Teak.log.exception(ex, false)` before calling `reportException(ex, null)` to send the Sentry crash report -- but the emit synchronously invokes the host's `LogListener` unguarded, so a throwing listener would unwind out of `uncaughtException` and drop the Sentry report along with it.
- Wraps the emit in `try/catch(Throwable)`, swallowing silently. Scoped to the fatal path only (`uncaughtException`); the caught path is unaffected.
- Mirrors iOS's fix for the identical gap (teak-ios@909c089).

## Test plan
- [x] `UncaughtExceptionLogEventTest.uncaughtExceptionStillReportsWhenLogListenerThrows` -- installs a throwing `LogListener`, calls `uncaughtException`, asserts `reportException` still queued a Sentry report.
- [x] Verified red-on-revert: removing the guard fails the new test with the propagating `RuntimeException`.
- [x] Full `testDebugUnitTest` suite green.
- [x] `./org_json_check`, `./check_thread_use`, `./format-code` clean.