### PR TITLE
Only report notification receipt when the OS would display the notification

### DIFF
--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,2 +1,2 @@
 bug:
-  - "Notification receipt is no longer reported when the OS would not display the notification, either because notifications are disabled for the app or because the notification's channel is blocked. This matches iOS, which reports receipt from the notification service extension only when an alert is displayed."
+  - "Notification receipt is no longer reported when the OS would not display the notification, either because notifications are disabled for the app or because the notification's channel is blocked."

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,0 +1,2 @@
+bug:
+  - "Notification receipt is no longer reported when the OS would not display the notification, either because notifications are disabled for the app or because the notification's channel is blocked. This matches iOS, which reports receipt from the notification service extension only when an alert is displayed."

--- a/src/main/java/io/teak/sdk/NotificationBuilder.java
+++ b/src/main/java/io/teak/sdk/NotificationBuilder.java
@@ -51,6 +51,7 @@ import javax.net.ssl.HttpsURLConnection;
 
 import androidx.annotation.NonNull;
 import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
 import io.teak.sdk.configuration.RemoteConfiguration;
 import io.teak.sdk.core.Result;
 import io.teak.sdk.json.JSONArray;
@@ -326,6 +327,34 @@ public class NotificationBuilder {
             }
         }
         return NotificationBuilder.DEFAULT_NOTIFICATION_CHANNEL_ID;
+    }
+
+    /**
+     * Determine whether the system would display this notification.
+     *
+     * This mirrors iOS, where receipt is reported by the notification service extension, which the
+     * system only runs when it is going to display an alert. It deliberately does not consider
+     * whether the game is in the foreground: iOS runs the extension regardless of app state, so a
+     * notification withheld because the game is foregrounded still counts as displayable here.
+     */
+    public static boolean canDisplayNotification(@NonNull Context context, @NonNull TeakNotification teakNotification) {
+        if (!NotificationManagerCompat.from(context).areNotificationsEnabled()) {
+            return false;
+        }
+
+        final NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && notificationManager != null) {
+            final String channelId = NotificationBuilder.channelIdForOptOutId(context, teakNotification.teakOptOutCategory);
+            final NotificationChannel channel = notificationManager.getNotificationChannel(channelId);
+
+            // A channel that does not exist yet is created when the notification is displayed, so treat
+            // it as displayable. Only a blocked channel is not: IMPORTANCE_MIN still displays, minimized.
+            if (channel != null && channel.getImportance() == NotificationManager.IMPORTANCE_NONE) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public static void configureNotificationChannelId(Context context, Teak.Channel.Category category) {

--- a/src/main/java/io/teak/sdk/NotificationBuilder.java
+++ b/src/main/java/io/teak/sdk/NotificationBuilder.java
@@ -330,12 +330,12 @@ public class NotificationBuilder {
     }
 
     /**
-     * Determine whether the system would display this notification.
+     * Determine whether the OS would display this notification.
      *
-     * This mirrors iOS, where receipt is reported by the notification service extension, which the
-     * system only runs when it is going to display an alert. It deliberately does not consider
-     * whether the game is in the foreground: iOS runs the extension regardless of app state, so a
-     * notification withheld because the game is foregrounded still counts as displayable here.
+     * Answers that question only, and deliberately says nothing about whether the game is in the
+     * foreground: a notification the game withholds while foregrounded is still displayable by this
+     * measure. iOS reports receipt from its notification service extension, which the system runs
+     * regardless of app state, so foregrounded receipts are reported there too.
      */
     public static boolean canDisplayNotification(@NonNull Context context, @NonNull TeakNotification teakNotification) {
         if (!NotificationManagerCompat.from(context).areNotificationsEnabled()) {

--- a/src/main/java/io/teak/sdk/core/TeakCore.java
+++ b/src/main/java/io/teak/sdk/core/TeakCore.java
@@ -157,6 +157,11 @@ public class TeakCore {
                     final Context context = ((PushNotificationEvent) event).context;
                     if (isHealthCheckPush || bundle.containsKey("teakExpectedDisplay")) {
                         final boolean expectedDisplay = Helpers.getBooleanFromBundle(bundle, "teakExpectedDisplay");
+
+                        // Keyed off the app-level toggle by design, and intentionally not the same
+                        // question the receipt gate below asks. This tracks the global notification
+                        // setting; receipt reporting asks whether the OS would display one specific
+                        // notification, which also depends on that notification's channel.
                         final boolean canDisplayNotification = NotificationManagerCompat.from(context).areNotificationsEnabled();
                         final boolean shouldSendHealthCheck = isHealthCheckPush || (expectedDisplay != canDisplayNotification);
 
@@ -190,10 +195,10 @@ public class TeakCore {
 
                     // Create & display native notification asynchronously, image downloads etc
                     asyncExecutor.submit(new RetriableTask<>(3, 2000L, 2, () -> {
-                        // Send metric, but only if the system would display this notification. This
-                        // matches iOS, where receipt is reported by the notification service extension,
-                        // which the system only runs when it is going to display an alert. A notification
-                        // withheld because the game is in the foreground is still reported, as on iOS.
+                        // Send metric, but only if the OS would display this notification. A notification
+                        // withheld because the game is in the foreground is still reported: iOS reports
+                        // receipt from its notification service extension, which the system runs
+                        // regardless of app state, so foregrounded receipts are reported there too.
                         final String teakUserId = bundle.getString("teakUserId", null);
                         final String teakAppId = bundle.getString("teakAppId", null);
                         if (teakAppId != null && teakUserId != null && NotificationBuilder.canDisplayNotification(context, teakNotification)) {

--- a/src/main/java/io/teak/sdk/core/TeakCore.java
+++ b/src/main/java/io/teak/sdk/core/TeakCore.java
@@ -190,10 +190,13 @@ public class TeakCore {
 
                     // Create & display native notification asynchronously, image downloads etc
                     asyncExecutor.submit(new RetriableTask<>(3, 2000L, 2, () -> {
-                        // Send metric
+                        // Send metric, but only if the system would display this notification. This
+                        // matches iOS, where receipt is reported by the notification service extension,
+                        // which the system only runs when it is going to display an alert. A notification
+                        // withheld because the game is in the foreground is still reported, as on iOS.
                         final String teakUserId = bundle.getString("teakUserId", null);
                         final String teakAppId = bundle.getString("teakAppId", null);
-                        if (teakAppId != null && teakUserId != null) {
+                        if (teakAppId != null && teakUserId != null && NotificationBuilder.canDisplayNotification(context, teakNotification)) {
                             HashMap<String, Object> payload = new HashMap<>();
                             payload.put("app_id", teakAppId);
                             payload.put("user_id", teakUserId);


### PR DESCRIPTION
Android reported `notification_received` on every push receipt, independent of whether the notification would be displayed. iOS reports receipt from the notification service extension, which the system only runs when it's going to display an alert — so Android over-reported relative to iOS.

Gates the metric on a new `NotificationBuilder.canDisplayNotification`: false when notifications are disabled app-level, or when the channel the notification would post to is blocked. Channel resolution reuses the existing `channelIdForOptOutId`, so the gate asks about the same channel the notification would actually post to rather than a parallel reimplementation.

**Black box**: in → a received push; out → `notification_received` POSTed to parsnip, or not. Only the not-displayable cases change. Display logic and payload contents are untouched.

### The issue's premise didn't survive reading iOS

C-1023 says iOS "only reports if an alert is displayed" — implying we should gate on Android's display branch. That's **not** what iOS does. `TeakNotificationServiceCore.m:163` sends the metric from `didReceiveNotificationRequest`, which the OS runs for any `mutable-content` alert push, *before* any display decision and *regardless of app state*. So iOS reports even when the app is foregrounded and the alert is never shown; it only stays silent when notifications are OS-disabled.

Gating on Android's display branch would therefore have suppressed the foreground case that iOS reports — an Android-only divergence shipped as "parity". alex confirmed the intent is "would the OS have displayed this?", so **foreground reporting is deliberately untouched**.

### Deliberate non-changes

- **Foreground** — still reported (with `notification_placement: foreground`), matching iOS.
- **`/push_state` health check** — keeps its own app-level-only check. It now asks a different question than the metric gate (a blocked-channel-but-notifications-on user gets no receipt, but no push_state mismatch either). That's intentional per alex: the health check tracks the global toggle; per-notification reporting tracks displayability.

### Judgment calls worth reviewing

- **Blocked == `IMPORTANCE_NONE` only.** `IMPORTANCE_MIN` still displays (minimized) — `PushState.java:243` notes settings-"Low" maps to `IMPORTANCE_MIN`. Gating on `MIN` would suppress receipts for notifications users actually see.
- **Channel `null` → treated as displayable (fail-open).** The default `teak` channel is created lazily at display time, so it legitimately doesn't exist on first push. Fail-open matches iOS: report unless we *know* it won't show.
- **Pre-O**: app-level check only; channels don't exist.
- **No new NPE class**: `PushNotificationEvent`'s ctor is `@NonNull Context` and both `Received` producers (FCM/ADM) pass real contexts; existing code already dereferences `context` at `:160`/`:226`.

### On tests — deliberately none

There is **no honest regression test available here**, and I'd rather say so than ship one that guards nothing:

1. `TeakCore.java:126`'s `isUnitTest` short-circuits the `Request.submit` — unit tests never send at all, so "assert no receipt when disabled" **passes on unfixed code**. False green.
2. Unit tests run with `Build.VERSION.SDK_INT == 0` (no Robolectric, `returnDefaultValues = true`), so the channel branch **cannot execute** on the JVM.

Testing the helper would need Robolectric or a new injectable notification-manager seam (`IAndroidNotification` only does cancel/display) — a refactor beyond a patch cut. **alex's on-device sample test is the real gate.** Filing a followup for the testability gap.

Verified: `./gradlew assemble` builds both AARs; `(cd test_app && ./gradlew testDebugUnitTest)` green (root-level runs are a known false green).

Closes C-1023
