### PR TITLE
Extend Google Play Billing support down to 6.x

### DIFF
--- a/docs/modules/changelog/versions/4.3.17.yaml
+++ b/docs/modules/changelog/versions/4.3.17.yaml
@@ -1,2 +1,2 @@
 bug:
-  - "Resolve purchase tracking failure on Billing Library 8.0+"
+  - "Automatic Google Play purchase tracking now works across Billing Library 6 through 9."

--- a/src/main/java/io/teak/sdk/DefaultObjectFactory.java
+++ b/src/main/java/io/teak/sdk/DefaultObjectFactory.java
@@ -129,7 +129,7 @@ public class DefaultObjectFactory implements IObjectFactory {
         } else {
             try {
                 // Check if the billing library is present at all, then use the single
-                // GooglePlayBilling store — it is runtime-compatible across billing 7, 8, and 9.
+                // GooglePlayBilling store — it is runtime-compatible across billing 6, 7, 8, and 9.
                 Class.forName("com.android.billingclient.api.BillingClient");
                 clazz = Class.forName("io.teak.sdk.store.GooglePlayBilling");
             } catch (Throwable e) {

--- a/src/main/java/io/teak/sdk/store/GooglePlayBilling.java
+++ b/src/main/java/io/teak/sdk/store/GooglePlayBilling.java
@@ -49,7 +49,7 @@ public class GooglePlayBilling implements Unobfuscable, IStore, PurchasesUpdated
         // tells us which billing version was being set up.
         Teak.log.i("billing.google", "Registering Google Play Billing.", Helpers.mm.h("billing_version", billingLibraryVersion()));
 
-        this.billingClient = enablePendingPurchases(BillingClient.newBuilder(context).setListener(this)).build();
+        this.billingClient = enablePendingPurchases(BillingClient.newBuilder(context).setListener(this), pendingPurchasesParamsAvailable()).build();
 
         this.billingClient.startConnection(this);
     }
@@ -58,8 +58,13 @@ public class GooglePlayBilling implements Unobfuscable, IStore, PurchasesUpdated
     // deprecated no-arg one (removed again in 8+, which is why 7+ always prefers the typed
     // overload here). Gate on class presence rather than calling the no-arg overload
     // unconditionally, since that one doesn't exist at all on 8+.
-    private static BillingClient.Builder enablePendingPurchases(BillingClient.Builder builder) {
-        if (pendingPurchasesParamsAvailable()) {
+    //
+    // Package-private + boolean-injectable so both selections are unit-testable against a mocked
+    // Builder — CI always runs against the 7.1.1 compileOnly floor, so pendingPurchasesParamsAvailable()
+    // itself can only ever probe "present" there; injecting the flag lets the no-arg (6.x) branch
+    // get a real regression guard too.
+    static BillingClient.Builder enablePendingPurchases(BillingClient.Builder builder, boolean pendingPurchasesParamsAvailable) {
+        if (pendingPurchasesParamsAvailable) {
             return builder.enablePendingPurchases(PendingPurchasesParams.newBuilder().enableOneTimeProducts().build());
         }
         return builder.enablePendingPurchases();

--- a/src/main/java/io/teak/sdk/store/GooglePlayBilling.java
+++ b/src/main/java/io/teak/sdk/store/GooglePlayBilling.java
@@ -29,15 +29,18 @@ import io.teak.sdk.Unobfuscable;
 import io.teak.sdk.event.PurchaseEvent;
 
 // Single Google Play Billing store. Teak compiles against billing 7.1.1 but the host game
-// supplies the runtime library; this class is runtime-compatible across billing 7, 8, and 9.
+// supplies the runtime library; this class is runtime-compatible across billing 6, 7, 8, and 9.
 //
-// Only one billing API the tracking path uses diverges across those versions: the
-// product-details query callback hands back a List<ProductDetails> on 7 and a
-// QueryProductDetailsResult on 8+. That listener is registered through a dynamic proxy whose
-// sole job is to normalize the second argument back to List<ProductDetails>. Every other call —
-// client construction, enablePendingPurchases, purchases-updated, the product-details query
-// itself, and the price read — is a single native call site valid on all three versions
-// (verified against the 7.1.1 / 8.3.0 / 9.1.0 runtime interfaces).
+// Two billing APIs the tracking path uses diverge across those versions:
+// - enablePendingPurchases: 6.x only has the no-arg overload (PendingPurchasesParams doesn't
+//   exist below billing 7.0); 7.x has both; 8+ only has the PendingPurchasesParams overload (the
+//   no-arg one was removed). Gated by a Class.forName check on PendingPurchasesParams.
+// - the product-details query callback hands back a List<ProductDetails> on 6-7 and a
+//   QueryProductDetailsResult on 8+. That listener is registered through a dynamic proxy whose
+//   sole job is to normalize the second argument back to List<ProductDetails>.
+// Every other call — client construction, purchases-updated, the product-details query itself,
+// and the price read — is a single native call site valid on all four versions (verified against
+// the 6.2.1 / 7.1.1 / 8.3.0 / 9.1.0 runtime interfaces).
 public class GooglePlayBilling implements Unobfuscable, IStore, PurchasesUpdatedListener, BillingClientStateListener {
     private final BillingClient billingClient;
 
@@ -46,12 +49,31 @@ public class GooglePlayBilling implements Unobfuscable, IStore, PurchasesUpdated
         // tells us which billing version was being set up.
         Teak.log.i("billing.google", "Registering Google Play Billing.", Helpers.mm.h("billing_version", billingLibraryVersion()));
 
-        this.billingClient = BillingClient.newBuilder(context)
-                                 .setListener(this)
-                                 .enablePendingPurchases(PendingPurchasesParams.newBuilder().enableOneTimeProducts().build())
-                                 .build();
+        this.billingClient = enablePendingPurchases(BillingClient.newBuilder(context).setListener(this)).build();
 
         this.billingClient.startConnection(this);
+    }
+
+    // billing 7+ has the PendingPurchasesParams-typed overload; billing 6.x only has the
+    // deprecated no-arg one (removed again in 8+, which is why 7+ always prefers the typed
+    // overload here). Gate on class presence rather than calling the no-arg overload
+    // unconditionally, since that one doesn't exist at all on 8+.
+    private static BillingClient.Builder enablePendingPurchases(BillingClient.Builder builder) {
+        if (pendingPurchasesParamsAvailable()) {
+            return builder.enablePendingPurchases(PendingPurchasesParams.newBuilder().enableOneTimeProducts().build());
+        }
+        return builder.enablePendingPurchases();
+    }
+
+    // Package-private so the version gate is unit-testable without a real BillingClient.Builder
+    // (which needs the Android runtime, per CreateStoreTest).
+    static boolean pendingPurchasesParamsAvailable() {
+        try {
+            Class.forName("com.android.billingclient.api.PendingPurchasesParams");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
     }
 
     // The Play Billing version the host game actually ships, read reflectively. A direct reference

--- a/src/main/java/io/teak/sdk/store/GooglePlayBilling.java
+++ b/src/main/java/io/teak/sdk/store/GooglePlayBilling.java
@@ -78,7 +78,7 @@ public class GooglePlayBilling implements Unobfuscable, IStore, PurchasesUpdated
 
     // The Play Billing version the host game actually ships, read reflectively. A direct reference
     // to BillingClient.BuildConfig.VERSION_NAME would inline to Teak's compileOnly version (7.1.1)
-    // at compile time; reading the field reflectively yields the real runtime version (7, 8, or 9).
+    // at compile time; reading the field reflectively yields the real runtime version (6, 7, 8, or 9).
     // Best-effort — returns "unknown" if the constant can't be read.
     private static String billingLibraryVersion() {
         try {
@@ -127,8 +127,8 @@ public class GooglePlayBilling implements Unobfuscable, IStore, PurchasesUpdated
         }
     }
 
-    // The one version-divergent call. Billing 7 invokes the listener with a List<ProductDetails>;
-    // billing 8+ invokes it with a QueryProductDetailsResult. We implement whichever
+    // Billing 6-7 invokes the listener with a List<ProductDetails>; billing 8+ invokes it with a
+    // QueryProductDetailsResult. We implement whichever
     // ProductDetailsResponseListener the runtime declares via a dynamic proxy so the same code
     // links against every version, and normalize the second argument in onProductDetails.
     private ProductDetailsResponseListener productDetailsListener(final String purchaseSku, final Map<String, Object> payload) {
@@ -168,7 +168,7 @@ public class GooglePlayBilling implements Unobfuscable, IStore, PurchasesUpdated
         }
     }
 
-    // Billing 7: the argument is already the List<ProductDetails>. Billing 8+: it is a
+    // Billing 6-7: the argument is already the List<ProductDetails>. Billing 8+: it is a
     // QueryProductDetailsResult whose getProductDetailsList() yields the List. Reflection is
     // confined to this single unwrap — there is no second code path to fall into.
     // Package-private so the version-divergence unwrap is unit-testable without a real BillingClient.

--- a/test_app/app/src/test/java/io/teak/sdk/store/EnablePendingPurchasesTest.java
+++ b/test_app/app/src/test/java/io/teak/sdk/store/EnablePendingPurchasesTest.java
@@ -1,16 +1,45 @@
 package io.teak.sdk.store;
 
+import com.android.billingclient.api.BillingClient;
+import com.android.billingclient.api.PendingPurchasesParams;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 // Guards GooglePlayBilling's enablePendingPurchases version gate (PendingPurchasesParams exists
-// on billing 7+, not on 6.x). The gate is classpath-driven rather than argument-driven, so a JVM
-// unit test can only exercise the branch matching whatever billing jar is on ITS classpath --
-// test_app pins billing to 7.1.1 to match Teak's compileOnly floor, so PendingPurchasesParams
-// resolves here. The no-arg fallback (billing 6.x, where the class doesn't exist) is proven
-// on-device instead, the same split CreateStoreTest documents for store instantiation.
+// on billing 7+, not on 6.x). The boolean is injected rather than read live so both selections get
+// a real regression guard against a mocked Builder -- CI always runs against the 7.1.1 compileOnly
+// floor, so the live probe (pendingPurchasesParamsAvailable(), covered separately below) can only
+// ever exercise "present" there.
 public class EnablePendingPurchasesTest {
+    @Test
+    public void available_choosesTypedOverload() {
+        final BillingClient.Builder builder = mock(BillingClient.Builder.class);
+        when(builder.enablePendingPurchases(any(PendingPurchasesParams.class))).thenReturn(builder);
+
+        GooglePlayBilling.enablePendingPurchases(builder, true);
+
+        verify(builder).enablePendingPurchases(any(PendingPurchasesParams.class));
+        verify(builder, never()).enablePendingPurchases();
+    }
+
+    @Test
+    public void unavailable_choosesNoArgOverload() {
+        final BillingClient.Builder builder = mock(BillingClient.Builder.class);
+        when(builder.enablePendingPurchases()).thenReturn(builder);
+
+        GooglePlayBilling.enablePendingPurchases(builder, false);
+
+        verify(builder).enablePendingPurchases();
+        verify(builder, never()).enablePendingPurchases(any(PendingPurchasesParams.class));
+    }
+
     @Test
     public void pendingPurchasesParams_resolvesOnTheCompileOnlyFloor() {
         assertTrue(GooglePlayBilling.pendingPurchasesParamsAvailable());

--- a/test_app/app/src/test/java/io/teak/sdk/store/EnablePendingPurchasesTest.java
+++ b/test_app/app/src/test/java/io/teak/sdk/store/EnablePendingPurchasesTest.java
@@ -1,0 +1,18 @@
+package io.teak.sdk.store;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+// Guards GooglePlayBilling's enablePendingPurchases version gate (PendingPurchasesParams exists
+// on billing 7+, not on 6.x). The gate is classpath-driven rather than argument-driven, so a JVM
+// unit test can only exercise the branch matching whatever billing jar is on ITS classpath --
+// test_app pins billing to 7.1.1 to match Teak's compileOnly floor, so PendingPurchasesParams
+// resolves here. The no-arg fallback (billing 6.x, where the class doesn't exist) is proven
+// on-device instead, the same split CreateStoreTest documents for store instantiation.
+public class EnablePendingPurchasesTest {
+    @Test
+    public void pendingPurchasesParams_resolvesOnTheCompileOnlyFloor() {
+        assertTrue(GooglePlayBilling.pendingPurchasesParamsAvailable());
+    }
+}

--- a/test_app/app/src/test/java/io/teak/sdk/store/NormalizeProductDetailsTest.java
+++ b/test_app/app/src/test/java/io/teak/sdk/store/NormalizeProductDetailsTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 // Guards GooglePlayBilling.normalizeProductDetails — the one billing-version-divergent step the
-// whole SDK fix hinges on. Billing 7 hands the product-details callback a List<ProductDetails>;
+// whole SDK fix hinges on. Billing 6-7 hands the product-details callback a List<ProductDetails>;
 // billing 8+ hands it a QueryProductDetailsResult whose getProductDetailsList() yields the List.
 // These fakes stand in for both shapes so the unwrap is verified without a real BillingClient.
 public class NormalizeProductDetailsTest {
@@ -33,7 +33,7 @@ public class NormalizeProductDetailsTest {
     @Test
     public void billing7Shape_listPassesThroughUnchanged() {
         final List<Object> list = Arrays.asList(new Object(), new Object());
-        // Billing 7: the argument already IS the List, returned as-is.
+        // Billing 6-7: the argument already IS the List, returned as-is.
         assertSame(list, GooglePlayBilling.normalizeProductDetails(list));
     }
 


### PR DESCRIPTION
Extends #175's single Google Play Billing store class down to support Billing Library 6.x (previously 7-9 only).

### What changed
`GooglePlayBilling`'s ctor hard-referenced `PendingPurchasesParams`, which doesn't exist below Billing Library 7.0 — on 6.x the store failed to construct (caught by `DefaultObjectFactory.createStore`'s `catch(Exception)`, so no crash, but also no purchase tracking). `enablePendingPurchases` is now gated on a `Class.forName` check: typed `PendingPurchasesParams` overload when present (7-9), deprecated no-arg overload when absent (6.x — which lacks the typed overload entirely; 8+ lacks the no-arg one, hence 7+ always preferring typed).

`compileOnly` stays at 7.1.1 — javap'd every symbol the store touches against real 6.2.1/7.1.1/8.3.0/9.1.0 jars; `enablePendingPurchases` is the only divergence beyond the already-handled product-details callback shape.

### Verification (on-device, all 4 real versions)
Built the example app against 6.2.1/7.1.1/8.3.0/9.1.0 via `-PbillingVersion`, confirmed via gradle dependency resolution + APK dex string grep + the SDK's own reflective `billing_version` log that each build actually carried the intended version (no silent resolution bump). Installed + launched on a physical device each time: store constructs and connects cleanly (`onBillingSetupFinished` responseCode 0) with no exception logged, on all four.

**Not exercised: a full end-to-end purchase.** This proves construct+connect, not a real transaction.

Added `EnablePendingPurchasesTest` guarding the version-gate helper (JVM-testable branch only — the classpath here matches the 7.1.1 compileOnly floor, so it proves detection-when-present; the no-arg fallback on 6.x is proven on-device instead, same split `CreateStoreTest` already documents for instantiation).

Changelog line updated to describe the full 6-9 range (supersedes the 8.0+-only wording from #175).

Closes https://linear.app/teakio/issue/C-1180

🤖 Generated with [Claude Code](https://claude.com/claude-code)