### PR TITLE
Document that Teak.Notification.schedule requires an existing creative (4.3-stable)

### DIFF
--- a/src/main/java/io/teak/sdk/Teak.java
+++ b/src/main/java/io/teak/sdk/Teak.java
@@ -671,7 +671,8 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
     public static class Notification implements Unobfuscable {
         /**
          * Class used to communicate replies to:
-         * - {@link Notification#schedule(String, long, Map)} ()}
+         * - {@link Notification#schedule(String, long)}
+         * - {@link Notification#schedule(String, long, Map)}
          */
         public static class Reply implements Unobfuscable {
             public enum Status {
@@ -723,7 +724,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
 
         /**
          * Schedule a notification to be sent to the current user in the future
-         * @param creativeId     The identifier of the notification creative on the Teak dashboard.
+         * @param creativeId     The identifier of the notification creative on the Teak dashboard, this must already exist.
          * @param delayInSeconds The delay, in seconds, before sending the notification.
          * @return A {@link Future} for the {@link Reply} to this operation.
          */
@@ -741,7 +742,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
 
         /**
          * Schedule a notification to be sent to the current user in the future
-         * @param creativeId            The identifier of the notification creative on the Teak dashboard.
+         * @param creativeId            The identifier of the notification creative on the Teak dashboard, this must already exist.
          * @param delayInSeconds        The delay, in seconds, before sending the notification.
          * @param personalizationData   A dictionary containing parameters that the server can use for templating.
          * @return A {@link Future} for the {@link Reply} to this operation.


### PR DESCRIPTION
https://linear.app/teakio/issue/C-1230

Twin of #179 for the 4.3.x release line. `Teak.java`'s `Notification.schedule` overloads (2-arg and 3-arg-with-`personalizationData`) document `creativeId` with no mention of whether a missing creative auto-creates — silence, not a wrong claim; 4.3-stable never asserted auto-create here, same as develop before #179. Since 4.3.x is the released line and the constraint goes undocumented there too, backporting the two-line clarification (identical wording to #179, verbatim clause already used at `TeakNotification.java:418`) closes that gap for shipped customers rather than only new-release readers.

Also carries the same stray javadoc `()}` artifact fix from #179's second commit, present verbatim on this branch too.

Hand-applied, not a cherry-pick — `Teak.java` has diverged elsewhere between develop and 4.3-stable.