### PR TITLE
Fix inert clang-format pre-commit hook and reformat tree (C-1231)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Commits listed here are ignored by `git blame` (GitHub honors this file
+# automatically; locally: `git blame --ignore-revs-file .git-blame-ignore-revs`
+# or `git config blame.ignoreRevsFile .git-blame-ignore-revs`).
+
+# Bring the tree conformant to clang-format (C-1231)
+d7857bc13b71338c01b812ef9c0bd6fe4aff3b62

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ These run in CI and will fail the build if violated:
 - **`./org_json_check`** — No imports of `org.json.*` allowed. Must use vendored `io.teak.sdk.json.*` (exists to avoid Android API < 19 differences).
 - **`./check_thread_use`** — No direct `import java.util.concurrent.Executors` except in `Executors.java`. All executor creation goes through `io.teak.sdk.core.Executors`.
 
-`./validate-code-format` is **not** run by CI — it's local-only, wired up as a pre-commit hook (`pre-commit` → `./validate-code-format`). It's the sole enforcement point for clang-format style, including `.java`.
+`./validate-code-format` is **not** run by CI — it's local-only, wired up as a pre-commit hook (`pre-commit` → `./validate-code-format`). It's the sole enforcement point for clang-format style, including `.java`. The hook installs (and self-repairs) itself automatically on every root `./gradlew` invocation (not `test_app/`'s or `example/`'s, which are separate Gradle projects), so there's no separate setup step to remember for the common case; it's still opt-out via `git commit --no-verify` like any hook.
 
 ## Code Style
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,36 @@ apply plugin: 'com.android.library'
 
 import static groovy.io.FileType.FILES
 
+// Install/refresh the clang-format pre-commit hook on every Gradle invocation, so
+// enforcement can't silently go inert -- a hook a developer has to remember to
+// install manually just doesn't get installed. This
+// intentionally does not depend on --git-path resolving *this* worktree: hooks
+// live in the shared common git dir across all worktrees of a checkout, and the
+// hook body below re-resolves the currently active worktree at commit time via
+// `git rev-parse --show-toplevel`, so it always runs whichever worktree's tracked
+// pre-commit/validate-code-format is actually checked out.
+try {
+    def hooksPredicateOut = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'rev-parse', '--git-path', 'hooks/pre-commit'
+        workingDir project.rootDir
+        standardOutput = hooksPredicateOut
+        errorOutput = new ByteArrayOutputStream()
+    }
+    def hookFile = file(hooksPredicateOut.toString().trim())
+    def hookScript = '''#!/bin/bash
+set -euo pipefail
+exec "$(git rev-parse --show-toplevel)/pre-commit" "$@"
+'''
+    if (!hookFile.exists() || hookFile.text != hookScript) {
+        hookFile.parentFile.mkdirs()
+        hookFile.text = hookScript
+    }
+    hookFile.setExecutable(true)
+} catch (Exception e) {
+    logger.warn("Could not install git pre-commit hook (formatting won't be enforced locally): ${e.message}")
+}
+
 gradle.projectsEvaluated {
     android.libraryVariants.all { variant ->
 

--- a/example/app/src/main/java/io/teak/app/java/dev/MainActivity.java
+++ b/example/app/src/main/java/io/teak/app/java/dev/MainActivity.java
@@ -74,26 +74,26 @@ public class MainActivity extends AppCompatActivity {
     public void doTheThing(Teak.RewardClaimEvent event) {
         TeakNotification.Reward rewardInfo = event.reward;
         String rewardId = rewardInfo.json.getString("teakRewardId");
-        switch(rewardInfo.status) {
-        case TeakNotification.Reward.GRANT_REWARD: {
-          Map<String, Object> reward = rewardInfo.json.getJSONObject("reward").toMap();
-          Log.d("TeakExample.Reward", "Reward with id " + rewardId + "Granted! " + reward.toString());
-        } break;
-        case TeakNotification.Reward.ALREADY_CLICKED: {
-          Log.d("TeakExample.Reward", "You already claimed this reward!");
-        } break;
-        case TeakNotification.Reward.EXPIRED: {
-          Log.d("TeakExample.Reward", "The reward has expired");
-        } break;
-        case TeakNotification.Reward.TOO_MANY_CLICKS: {
-          Log.d("TeakExample.Reward", "Too many other players already claimed this reward");
-        } break;
-        case TeakNotification.Reward.EXCEED_MAX_CLICKS_FOR_DAY: {
-          Log.d("TeakExample.Reward", "You've already claimed too many rewards today");
-        } break;
-        default: {
-          Log.d("TeakExample.Reward", "The reward was rejected for a different reason: " + rewardInfo.json.getString("status"));
-        }
+        switch (rewardInfo.status) {
+            case TeakNotification.Reward.GRANT_REWARD: {
+                Map<String, Object> reward = rewardInfo.json.getJSONObject("reward").toMap();
+                Log.d("TeakExample.Reward", "Reward with id " + rewardId + "Granted! " + reward.toString());
+            } break;
+            case TeakNotification.Reward.ALREADY_CLICKED: {
+                Log.d("TeakExample.Reward", "You already claimed this reward!");
+            } break;
+            case TeakNotification.Reward.EXPIRED: {
+                Log.d("TeakExample.Reward", "The reward has expired");
+            } break;
+            case TeakNotification.Reward.TOO_MANY_CLICKS: {
+                Log.d("TeakExample.Reward", "Too many other players already claimed this reward");
+            } break;
+            case TeakNotification.Reward.EXCEED_MAX_CLICKS_FOR_DAY: {
+                Log.d("TeakExample.Reward", "You've already claimed too many rewards today");
+            } break;
+            default: {
+                Log.d("TeakExample.Reward", "The reward was rejected for a different reason: " + rewardInfo.json.getString("status"));
+            }
         }
         if (event.reward != null) {
             final StringBuilder rewardString = new StringBuilder("You got ");
@@ -117,10 +117,10 @@ public class MainActivity extends AppCompatActivity {
                 builder = new AlertDialog.Builder(MainActivity.this);
             }
             builder.setTitle("Reward!")
-                    .setMessage(rewardString.toString())
-                    .setPositiveButton(android.R.string.yes, null)
-                    .setIcon(android.R.drawable.ic_dialog_alert)
-                    .show();
+                .setMessage(rewardString.toString())
+                .setPositiveButton(android.R.string.yes, null)
+                .setIcon(android.R.drawable.ic_dialog_alert)
+                .show();
         }
     }
 
@@ -177,7 +177,7 @@ public class MainActivity extends AppCompatActivity {
         Teak.registerDeepLink("/store/:sku", "Store", "Link directly to purchase an item", new Teak.DeepLink() {
             @Override
             public void call(Map<String, Object> parameters) {
-                String sku = (String)parameters.get("sku");
+                String sku = (String) parameters.get("sku");
                 showPurchaseDialogForSku(sku);
             }
         });
@@ -195,10 +195,10 @@ public class MainActivity extends AppCompatActivity {
                             builder = new AlertDialog.Builder(MainActivity.this);
                         }
                         builder.setTitle("Slot!")
-                                .setMessage(parameters.get("slot_id").toString())
-                                .setPositiveButton(android.R.string.yes, null)
-                                .setIcon(android.R.drawable.ic_dialog_alert)
-                                .show();
+                            .setMessage(parameters.get("slot_id").toString())
+                            .setPositiveButton(android.R.string.yes, null)
+                            .setIcon(android.R.drawable.ic_dialog_alert)
+                            .show();
                     }
                 });
             }
@@ -279,15 +279,15 @@ public class MainActivity extends AppCompatActivity {
             animated.put("width", 512);
             animated.put("height", 256);*/
 
-            animated.put("sprite_sheet", "https://assets.teakcdn.com/creative_translations-media/53532/original-base64Default.txt?1518130762");//"assets:///teak-slots-banner-sprite.jpg");
+            animated.put("sprite_sheet", "https://assets.teakcdn.com/creative_translations-media/53532/original-base64Default.txt?1518130762"); //"assets:///teak-slots-banner-sprite.jpg");
             animated.put("display_ms", 200);
             animated.put("width", 1920);
             animated.put("height", 225);
 
-            //teak_notif_animated.put("text", "This is the text that doesn't end. Yes it goes on and on my friend. Some people started translating not knowing what it was, and they'll blow their translation budget just because...");
-            //teak_notif_animated.put("view_animator", animated);
+            // teak_notif_animated.put("text", "This is the text that doesn't end. Yes it goes on and on my friend. Some people started translating not knowing what it was, and they'll blow their translation budget just because...");
+            // teak_notif_animated.put("view_animator", animated);
             teak_notif_animated.put("left_image", "BUILTIN_APP_ICON");
-            //teak_notif_animated.put("left_image", "NONE");
+            // teak_notif_animated.put("left_image", "NONE");
             teak_notif_animated.put("notification_background", "assets:///AndroidPushGrid.png");
         } catch (Exception ignored) {
         }
@@ -313,7 +313,7 @@ public class MainActivity extends AppCompatActivity {
             animated.put("width", 2000);
             animated.put("height", 2000);
 
-            //teak_big_notif_image_text.put("text", "This is the text that doesn't end. Yes it goes on and on my friend. Some people started translating not knowing what it was, and they'll blow their translation budget just because...");
+            // teak_big_notif_image_text.put("text", "This is the text that doesn't end. Yes it goes on and on my friend. Some people started translating not knowing what it was, and they'll blow their translation budget just because...");
             teak_big_notif_image_text.put("view_animator", animated);
         } catch (Exception ignored) {
         }
@@ -321,13 +321,13 @@ public class MainActivity extends AppCompatActivity {
         // Display
         JSONObject display = new JSONObject();
         try {
-            //display.put("contentView", "teak_notif_animated");
-            //display.put("teak_notif_animated", teak_notif_animated);
+            // display.put("contentView", "teak_notif_animated");
+            // display.put("teak_notif_animated", teak_notif_animated);
             display.put("contentView", "teak_notif_no_title");
             display.put("teak_notif_no_title", teak_notif_animated);
 
-            //display.put("bigContentView", "teak_big_notif_image_text");
-            //display.put("teak_big_notif_image_text", teak_big_notif_image_text);
+            // display.put("bigContentView", "teak_big_notif_image_text");
+            // display.put("teak_big_notif_image_text", teak_big_notif_image_text);
             display.put("bigContentView", "teak_big_notif_animated");
             display.put("teak_big_notif_animated", teak_big_notif_image_text);
         } catch (Exception ignored) {
@@ -372,13 +372,13 @@ public class MainActivity extends AppCompatActivity {
         moveTaskToBack(true);
 
         // Simulate Notification
-//        final Handler handler = new Handler();
-//        handler.postDelayed(new Runnable() {
-//            @Override
-//            public void run() {
-//                simulateNotification(MainActivity.this);
-//            }
-//        }, 1000);
+        //        final Handler handler = new Handler();
+        //        handler.postDelayed(new Runnable() {
+        //            @Override
+        //            public void run() {
+        //                simulateNotification(MainActivity.this);
+        //            }
+        //        }, 1000);
     }
 
     public void makePurchase(View view) {
@@ -386,13 +386,13 @@ public class MainActivity extends AppCompatActivity {
     }
 
     public void crashApp(View view) {
-//        throw new RuntimeException("I crashed the app!");
-//        Teak.log.exception(new Raven.ReportTestException(Teak.SDKVersion));
-//        Teak.incrementEvent("debug_increment", null, null, 5);
-//        android.os.Process.sendSignal(android.os.Process.myPid(), android.os.Process.SIGNAL_QUIT);
-//        Teak.setChannelState(Teak.Channel.Type.PlatformPush, Teak.Channel.State.Available);
-//        Teak.openNotificationSettings();
-//        Teak.Notification.schedule("test_none", 5);
+        //        throw new RuntimeException("I crashed the app!");
+        //        Teak.log.exception(new Raven.ReportTestException(Teak.SDKVersion));
+        //        Teak.incrementEvent("debug_increment", null, null, 5);
+        //        android.os.Process.sendSignal(android.os.Process.myPid(), android.os.Process.SIGNAL_QUIT);
+        //        Teak.setChannelState(Teak.Channel.Type.PlatformPush, Teak.Channel.State.Available);
+        //        Teak.openNotificationSettings();
+        //        Teak.Notification.schedule("test_none", 5);
         Log.d(LOG_TAG, Teak.Channel.getCategoriesJson());
     }
 
@@ -475,10 +475,10 @@ public class MainActivity extends AppCompatActivity {
             wm.getDefaultDisplay().getMetrics(displayMetrics);
         }
         deviceMetricsView.setText(String.format(Locale.US, "device_memory_class: %d\nxdpi: %f\nydpi: %f\nwidth: %d\nheight: %d\ndensity: %f\ndensity_dpi: %d\nscaled_density: %f",
-                deviceMemoryClass,
-                displayMetrics.xdpi, displayMetrics.ydpi,
-                displayMetrics.widthPixels, displayMetrics.heightPixels,
-                displayMetrics.density, displayMetrics.densityDpi, displayMetrics.scaledDensity));
+            deviceMemoryClass,
+            displayMetrics.xdpi, displayMetrics.ydpi,
+            displayMetrics.widthPixels, displayMetrics.heightPixels,
+            displayMetrics.density, displayMetrics.densityDpi, displayMetrics.scaledDensity));
 
         // Really special
         final Configuration configuration = getResources().getConfiguration();
@@ -497,7 +497,7 @@ public class MainActivity extends AppCompatActivity {
 
         @Override
         public void onServiceConnected(ComponentName name,
-                                       IBinder service) {
+            IBinder service) {
             mService = IInAppBillingService.Stub.asInterface(service);
 
             // Clear inventory
@@ -506,7 +506,7 @@ public class MainActivity extends AppCompatActivity {
                     Bundle ownedItems = mService.getPurchases(3, getPackageName(), "inapp", null);
                     int response = ownedItems.getInt("RESPONSE_CODE");
                     if (response == 0) {
-                        ArrayList<String>  purchaseDataList = ownedItems.getStringArrayList("INAPP_PURCHASE_DATA_LIST");
+                        ArrayList<String> purchaseDataList = ownedItems.getStringArrayList("INAPP_PURCHASE_DATA_LIST");
 
                         for (int i = 0; i < purchaseDataList.size(); ++i) {
                             String purchaseData = purchaseDataList.get(i);
@@ -520,7 +520,7 @@ public class MainActivity extends AppCompatActivity {
 
                             // do something with this purchase information
                             // e.g. display the updated list of products owned by user
-                            //response =
+                            // response =
                         }
 
                         // if continuationToken != null, call getPurchases again

--- a/format-code
+++ b/format-code
@@ -2,4 +2,29 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-find src \( -path src/main/java/io/teak/sdk/shortcutbadger -o -path src/main/java/io/teak/sdk/json \) -prune -o -type f -name "*.java" -print | xargs clang-format -style=file -i
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Formats every tracked .java file -- the same set validate-code-format enforces
+# (all tracked .java, minus the vendored paths in format-vendored-paths, shared
+# with validate-code-format so the two scripts can't drift out of sync again).
+VENDORED_PATHS=()
+while IFS= read -r line; do
+    [ -n "$line" ] && VENDORED_PATHS+=("$line")
+done < "$SCRIPT_DIR/format-vendored-paths"
+
+is_vendored_path() {
+    local filename="$1"
+    local vendored
+
+    for vendored in "${VENDORED_PATHS[@]}"; do
+        case "$filename" in
+            "$vendored"/*) return 0 ;;
+        esac
+    done
+
+    return 1
+}
+
+git ls-files -- '*.java' | while read -r file; do
+    is_vendored_path "$file" || printf '%s\0' "$file"
+done | xargs -0 clang-format -style=file -i

--- a/format-vendored-paths
+++ b/format-vendored-paths
@@ -1,0 +1,2 @@
+src/main/java/io/teak/sdk/shortcutbadger
+src/main/java/io/teak/sdk/json

--- a/src/main/java/io/teak/sdk/Teak.java
+++ b/src/main/java/io/teak/sdk/Teak.java
@@ -436,7 +436,7 @@ public class Teak extends BroadcastReceiver implements Unobfuscable {
     public static void requestNotificationPermissions() {
         Teak.log.i("Teak.requestNotificationPermissions", "Hello");
 
-        if(Instance != null) {
+        if (Instance != null) {
             asyncExecutor.submit(() -> Instance.requestNotificationPermissions());
         }
     }

--- a/src/main/java/io/teak/sdk/TeakInstance.java
+++ b/src/main/java/io/teak/sdk/TeakInstance.java
@@ -127,9 +127,7 @@ public class TeakInstance implements Unobfuscable {
 
     void setMainActivity(Activity activity) {
         int newHashCode = activity.hashCode();
-        Teak.log.i("setMainActivity", Helpers.mm.h(
-            "oldHashCode", activityHashCode, "newHashCode", newHashCode, "name", activity.getComponentName().flattenToString()
-        ));
+        Teak.log.i("setMainActivity", Helpers.mm.h("oldHashCode", activityHashCode, "newHashCode", newHashCode, "name", activity.getComponentName().flattenToString()));
         this.mainActivity = activity;
         this.activityHashCode = newHashCode;
     }
@@ -561,10 +559,7 @@ public class TeakInstance implements Unobfuscable {
     private int activityHashCode;
 
     private void lifecycleTrace(String method, Activity activity) {
-        Teak.log.i("lifecycle_trace", Helpers.mm.h(
-            "callback", method, "name", activity.getComponentName().flattenToString(),
-            "ourHashCode", activityHashCode, "theirHashCode", activity.hashCode()
-        ));
+        Teak.log.i("lifecycle_trace", Helpers.mm.h("callback", method, "name", activity.getComponentName().flattenToString(), "ourHashCode", activityHashCode, "theirHashCode", activity.hashCode()));
     }
 
     // Needs to be public for TeakInitProvider
@@ -686,14 +681,13 @@ public class TeakInstance implements Unobfuscable {
     public void requestNotificationPermissions() {
         Teak.log.i("instance.requestNotificationPermissions", "trace");
         // Android pre 13 has no notification permissions.
-        if(Build.VERSION.SDK_INT < 33) {
+        if (Build.VERSION.SDK_INT < 33) {
             Teak.log.i("instance.requestNotificationPermissions", "Android < 13");
             return;
         }
 
         int permissionInfo = ContextCompat.checkSelfPermission(
-            this.context, Teak.NOTIFICATION_PERMISSION
-        );
+            this.context, Teak.NOTIFICATION_PERMISSION);
 
         if (permissionInfo == PackageManager.PERMISSION_GRANTED) {
             Teak.log.i("instance.requestNotificationPermissions", "Permission  granted");
@@ -708,7 +702,6 @@ public class TeakInstance implements Unobfuscable {
 
     ///// Permissions handling
     public void onNotificationPermissionResult(boolean result) {
-
     }
 
     ///// Built-in deep links

--- a/src/main/java/io/teak/sdk/activity/PermissionRequest.java
+++ b/src/main/java/io/teak/sdk/activity/PermissionRequest.java
@@ -8,42 +8,40 @@ import android.app.Activity;
 import io.teak.sdk.Unobfuscable;
 import android.content.pm.PackageManager;
 
-
 public class PermissionRequest extends Activity implements Unobfuscable {
-  static final int REQUEST_CODE = 1946157056;
+    static final int REQUEST_CODE = 1946157056;
 
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
 
-    doRequest();
-  }
-
-  private void doRequest() {
-    Teak.log.i("requestNotificationPermissions.doRequest", "Requesting push permissions");
-
-    if(!Teak.isEnabled()) {
-      Teak.log.e("requestNotificationPermissions.doRequest", "Teak is not enabled");
-      return;
+        doRequest();
     }
 
-    requestPermissions(new String[]{Teak.NOTIFICATION_PERMISSION}, REQUEST_CODE);
-  }
+    private void doRequest() {
+        Teak.log.i("requestNotificationPermissions.doRequest", "Requesting push permissions");
 
-  @Override
-  public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-    Teak.log.trace("requestNotificationPermissions.onRequestPermissionsResult");
-    if(requestCode != REQUEST_CODE) {
-      Teak.log.e("permission_request.onRequestPermissionsResult", "Result not for our request?", Helpers.mm.h("requestCode", requestCode, "permissions", permissions));
-      finish();
-      return;
+        if (!Teak.isEnabled()) {
+            Teak.log.e("requestNotificationPermissions.doRequest", "Teak is not enabled");
+            return;
+        }
+
+        requestPermissions(new String[] {Teak.NOTIFICATION_PERMISSION}, REQUEST_CODE);
     }
 
-    boolean granted = grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
-    Teak.Instance.onNotificationPermissionResult(granted);
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        Teak.log.trace("requestNotificationPermissions.onRequestPermissionsResult");
+        if (requestCode != REQUEST_CODE) {
+            Teak.log.e("permission_request.onRequestPermissionsResult", "Result not for our request?", Helpers.mm.h("requestCode", requestCode, "permissions", permissions));
+            finish();
+            return;
+        }
 
-    finish();
-    return;
-  }
+        boolean granted = grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
+        Teak.Instance.onNotificationPermissionResult(granted);
 
+        finish();
+        return;
+    }
 }

--- a/test_app/app/src/test/java/io/teak/app/test/DeepLinkRoutes.java
+++ b/test_app/app/src/test/java/io/teak/app/test/DeepLinkRoutes.java
@@ -100,9 +100,9 @@ public class DeepLinkRoutes extends TeakUnitTest {
     @Test
     public void queryWithPercentInTeakCreativeName() throws Exception {
         assertQueryDecoding("/store/item123"
-                + "?teak_notif_id=99999"
-                + "&teak_creative_name=50%25%20Off%20Sale"
-                + "&teak_schedule_name=Summer%20Promo",
+                                + "?teak_notif_id=99999"
+                                + "&teak_creative_name=50%25%20Off%20Sale"
+                                + "&teak_schedule_name=Summer%20Promo",
             "sku", "item123",
             "teak_notif_id", "99999",
             "teak_creative_name", "50% Off Sale",
@@ -113,9 +113,9 @@ public class DeepLinkRoutes extends TeakUnitTest {
     @Test
     public void queryWithPercentInTeakScheduleName() throws Exception {
         assertQueryDecoding("/store/item123"
-                + "?teak_notif_id=88888"
-                + "&teak_creative_name=Weekend%20Creative"
-                + "&teak_schedule_name=100%25%20Boost%20Weekend",
+                                + "?teak_notif_id=88888"
+                                + "&teak_creative_name=Weekend%20Creative"
+                                + "&teak_schedule_name=100%25%20Boost%20Weekend",
             "sku", "item123",
             "teak_notif_id", "88888",
             "teak_creative_name", "Weekend Creative",

--- a/test_app/app/src/test/java/io/teak/app/test/MalformedResponseHttpTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/MalformedResponseHttpTest.java
@@ -47,9 +47,9 @@ public class MalformedResponseHttpTest extends TeakHttpUnitTest {
     @Test
     public void htmlBodyFromEndpointFallsBackToEmptyJsonAndLogsBreadcrumb() throws Throwable {
         stubFor(post(urlEqualTo("/me/channel_state.json"))
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withBody("<html><body><h1>502 Bad Gateway</h1></body></html>")));
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("<html><body><h1>502 Bad Gateway</h1></body></html>")));
 
         Raven raven = new Raven(context, "sdk", TeakConfiguration.get(), objectFactory);
         Teak.log.setSdkRaven(raven);

--- a/test_app/app/src/test/java/io/teak/app/test/NotificationBroadcastReceivers.java
+++ b/test_app/app/src/test/java/io/teak/app/test/NotificationBroadcastReceivers.java
@@ -63,7 +63,7 @@ public class NotificationBroadcastReceivers {
 
         final PackageManager packageManager = mock(PackageManager.class);
         when(packageManager.getApplicationInfo(any(String.class), any(int.class))).thenReturn(applicationInfo);
-        
+
         final Resources resources = mock(Resources.class);
         when(resources.getIdentifier("config_notificationStripRemoteViewSizeBytes", "integer", "android")).thenReturn(0);
 

--- a/test_app/app/src/test/java/io/teak/app/test/TeakHttpUnitTest.java
+++ b/test_app/app/src/test/java/io/teak/app/test/TeakHttpUnitTest.java
@@ -42,19 +42,19 @@ public class TeakHttpUnitTest extends TeakUnitTest {
         Request.registerStaticEventListeners();
         final AppConfiguration appConfiguration = mock(AppConfiguration.class);
         final RemoteConfiguration remoteConfiguration =
-                new RemoteConfiguration(appConfiguration,
-                        "127.0.0.1",
-                        null,
-                        null,
-                        "mock_gcm_sender_id",
-                        "mock_firebase_app_id",
-                        false,
-                        false,
-                        null,
-                        null,
-                        600,
-                        new ArrayList<Teak.Channel.Category>(),
-                        true);
+            new RemoteConfiguration(appConfiguration,
+                "127.0.0.1",
+                null,
+                null,
+                "mock_gcm_sender_id",
+                "mock_firebase_app_id",
+                false,
+                false,
+                null,
+                null,
+                600,
+                new ArrayList<Teak.Channel.Category>(),
+                true);
         TeakEvent.postEvent(new RemoteConfigurationEvent(remoteConfiguration));
     }
 

--- a/validate-code-format
+++ b/validate-code-format
@@ -38,8 +38,10 @@ PARSE_EXTS=true
 # FILE_EXTS=".c .h .cpp .hpp"
 FILE_EXTS=".c .h .cpp .hpp .cc .hh .cxx .m .java"
 
-# vendored paths excluded from formatting/validation (mirrors format-code's prune list)
-VENDORED_PATHS="src/main/java/io/teak/sdk/shortcutbadger src/main/java/io/teak/sdk/json"
+# vendored paths excluded from formatting/validation -- shared with format-code
+# via format-vendored-paths so the two scripts can't drift out of sync.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENDORED_PATHS="$(tr '\n' ' ' < "$SCRIPT_DIR/format-vendored-paths")"
 
 ##################################################################
 # There should be no need to change anything below this line.

--- a/validate-code-format
+++ b/validate-code-format
@@ -120,7 +120,9 @@ fi
 # second -- the second run's empty-patch-means-clean check then sees the first
 # run's leftover, non-empty file and rejects a clean commit citing a stale
 # diff. mktemp sidesteps that entirely instead of just cleaning up after it.
-patch="$(mktemp -t pre-commit-clang-format)"
+# explicit XXXXXXXX template rather than `mktemp -t <prefix>`: the latter's
+# behavior differs between BSD/macOS and GNU coreutils mktemp, untested here.
+patch="$(mktemp "${TMPDIR:-/tmp}/pre-commit-clang-format.XXXXXXXX")"
 
 # create one patch containing all changes to the files
 git diff-index --cached --diff-filter=ACMR --name-only $against -- | while read file;

--- a/validate-code-format
+++ b/validate-code-format
@@ -24,10 +24,6 @@ if [ -z "$CLANG_FORMAT" ] && command -v brew >/dev/null 2>&1; then
     CLANG_FORMAT="$(brew --prefix clang-format 2>/dev/null)/bin/clang-format"
 fi
 
-# remove any older patches from previous commits. Set to true or false.
-# DELETE_OLD_PATCHES=false
-DELETE_OLD_PATCHES=false
-
 # only parse files with the extensions in FILE_EXTS. Set to true or false.
 # if false every changed file in the commit will be parsed with clang-format.
 # if true only files matching one of the extensions are parsed with clang-format.
@@ -119,13 +115,12 @@ if [ ! -x "$CLANG_FORMAT" ] ; then
     exit 1
 fi
 
-# create a random filename to store our generated patch
-prefix="pre-commit-clang-format"
-suffix="$(date +%s)"
-patch="/tmp/$prefix-$suffix.patch"
-
-# clean up any older clang-format patches
-$DELETE_OLD_PATCHES && rm -f /tmp/$prefix*.patch
+# create a uniquely-named file to store our generated patch. A whole-second
+# timestamp (the previous scheme) collides between two hook runs in the same
+# second -- the second run's empty-patch-means-clean check then sees the first
+# run's leftover, non-empty file and rejects a clean commit citing a stale
+# diff. mktemp sidesteps that entirely instead of just cleaning up after it.
+patch="$(mktemp -t pre-commit-clang-format)"
 
 # create one patch containing all changes to the files
 git diff-index --cached --diff-filter=ACMR --name-only $against -- | while read file;


### PR DESCRIPTION
Linear: https://linear.app/teakio/issue/1231

The `pre-commit` script has existed since 2017 but nothing ever installed it into `.git/hooks` — no install step existed anywhere (setup script, README, build.gradle). Formatting enforcement was completely inert and drift accumulated silently.

## What this does

1. **Widens `format-code`** to the same tracked-`.java` scope `validate-code-format` actually enforces — previously `format-code` only walked `src/`, while the hook validates any staged `.java` including `test_app/` and `example/`. Vendored-path exclusions are now a single shared `format-vendored-paths` file both scripts read, instead of two hand-synced copies.
2. **Reformats the tree** to clang-format baseline (whitespace-only, plus two `Helpers.mm.h(...)` call sites in `TeakInstance.java` hand-collapsed first so clang-format's `ColumnLimit: 0` hanging-indent output doesn't make them worse).
3. **Auto-installs the hook via `build.gradle`**, at project-evaluation time, so it happens on every root `./gradlew` invocation (not `test_app/`'s or `example/`'s, which are separate Gradle projects) rather than depending on a manual step nobody reruns. Resolves the shared git-common-dir hooks path so it works correctly across this org's multi-worktree checkouts, and the hook body re-resolves the active worktree at commit time so it always runs the currently-checked-out `pre-commit`/`validate-code-format`.
4. **Fixes a pre-existing same-second patch-filename collision** in `validate-code-format`, found in review: two hook runs within the same wall-clock second reused the same `/tmp` path, so a clean commit right after a rejected one could get falsely rejected citing the previous run's stale diff. This code path was unreachable before this PR (the hook was never installed) and reachable on every commit after. Fixed with `mktemp` using an explicit `XXXXXXXX` template — `mktemp -t <prefix>` was tried first, but its behavior is known to differ between BSD/macOS and GNU coreutils and that difference was **not tested** (no Linux box available in this session); the explicit template sidesteps the question rather than resolving it by inference.
5. `.git-blame-ignore-revs` for the reformat commit, so `git blame` on the touched files isn't buried under a whitespace-only commit.
6. Small CLAUDE.md note that install is now automatic (scoped to root `./gradlew`).

Note: the hook is still a local, opt-out-able (`--no-verify`) enforcement point, not a CI gate — that's consistent with how CLAUDE.md already documents this repo's intentional CI/hook split (redundant enforcement of the same thing twice).

## Testing

- `./format-code` twice: diff appears, then zero diff on rerun (idempotent). Vendored dirs (`json/`, `shortcutbadger/`) confirmed untouched.
- Token-level whitespace check (strip all whitespace, hash, compare per file) on the reformat commit's 8 files: all SAME-TOKENS — a stronger proof than `git diff -w`, which doesn't ignore removed blank lines and gives a false read here.
- Red-then-green on the actual installed hook, multiple times across scratch clones: staged a deliberately mis-indented file, confirmed `git commit` was rejected with the expected clang-format diff; reverted and confirmed a clean commit passes — including immediately after, with zero delay, which is the case the same-second collision fix specifically targets.
- `./gradlew help` — confirms `build.gradle` parses and the hook installs with the executable bit set.
- `(cd test_app && ./gradlew testDebugUnitTest)` — all green, unrelated to this change.
- `./org_json_check` and `./check_thread_use` — unaffected, both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)